### PR TITLE
added support to build python wrapper with installed pytorch ( pre-cxx11 abi)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,17 @@
 
 # rust
 Cargo.lock
+
+
+# distribution / packaging
+.Python
+build/
+dist/
+eggs/
+.eggs/
+sdist/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,9 @@ endif()
 
 if(NOT ENABLE_CXX11_ABI)
   add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
-  message(STATUS "Using the old C++-11 ABI, which is backwards compatible.")
+  message(STATUS "Using the pre C++-11 ABI, which is backwards compatible.")
 else()
-  message(STATUS "Using the new C++-11 ABI, which is not backwards compatible.")
+  message(STATUS "Using the C++-11 ABI, which is not backwards compatible.")
 endif()
 
 if(USE_CCACHE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 
 option(USE_CCACHE "Attempt using CCache to wrap the compilation" OFF)
+option(ENABLE_CXX11_ABI "Use the new C++-11 ABI, which is not backwards compatible." OFF)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -18,6 +19,13 @@ if(NOT CMAKE_BUILD_TYPE)
       CACHE STRING "Choose the type of build from: Debug Release RelWithDebInfo MinSizeRel Coverage." 
       FORCE
   )
+endif()
+
+if(NOT ENABLE_CXX11_ABI)
+  add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
+  message(STATUS "Using the old C++-11 ABI, which is backwards compatible.")
+else()
+  message(STATUS "Using the new C++-11 ABI, which is not backwards compatible.")
 endif()
 
 if(USE_CCACHE)
@@ -57,10 +65,18 @@ if (DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   message(STATUS "VCPKG_ROOT found, using vcpkg at $ENV{VCPKG_ROOT}")
 else()
   include(FetchContent)
-  FetchContent_Declare(vcpkg
-    GIT_REPOSITORY "https://github.com/microsoft/vcpkg.git"
-    GIT_TAG "2024.02.14"
-  )
+  if (ENABLE_CXX11_ABI)
+    FetchContent_Declare(vcpkg
+      GIT_REPOSITORY "https://github.com/microsoft/vcpkg.git"
+      GIT_TAG "2024.02.14"
+    )
+  else()
+    FetchContent_Declare(vcpkg
+      GIT_REPOSITORY "https://github.com/vectorch-ai/vcpkg.git"
+      GIT_TAG "ffc42e97c866ce9692f5c441394832b86548422c" # disable cxx11_abi
+    )
+    message(STATUS "Using custom vcpkg with cxx11_abi disabled")
+  endif()
   FetchContent_MakeAvailable(vcpkg)
 
   message(STATUS "VCPKG_ROOT not found, downloading and using vcpkg at ${vcpkg_SOURCE_DIR}")
@@ -112,9 +128,11 @@ find_package(NCCL REQUIRED)
 # libtorch requires python headers
 find_package(Python REQUIRED COMPONENTS Development)
 
-find_package(Jemalloc)
-if(Jemalloc_FOUND)
-  link_libraries(Jemalloc::jemalloc)
+if (ENABLE_CXX11_ABI)
+  find_package(Jemalloc)
+  if(Jemalloc_FOUND)
+    link_libraries(Jemalloc::jemalloc)
+  endif()
 endif()
 
 # Important Note: Always invoke find_package for other dependencies
@@ -127,11 +145,19 @@ else()
   include(FetchContent)
   if (CUDA_VERSION VERSION_GREATER_EQUAL 12.1)
     # download libtorch 2.2.1 with cuda 12.1 from pytorch.org
-    set(LIBTORCH_URL "https://download.pytorch.org/libtorch/cu121/libtorch-cxx11-abi-shared-with-deps-2.2.1%2Bcu121.zip")
+    if (ENABLE_CXX11_ABI)
+      set(LIBTORCH_URL "https://download.pytorch.org/libtorch/cu121/libtorch-cxx11-abi-shared-with-deps-2.2.1%2Bcu121.zip")
+    else()
+      set(LIBTORCH_URL "https://download.pytorch.org/libtorch/cu121/libtorch-shared-with-deps-2.2.1%2Bcu121.zip")
+    endif()
     message(STATUS "LIBTORCH_ROOT not found, downloading and using libtorch 2.2.1 for cuda ${CUDA_VERSION}")
   elseif(CUDA_VERSION VERSION_GREATER_EQUAL 11.8)
     # download libtorch 2.2.1 with cuda 11.8 from pytorch.org
-    set(LIBTORCH_URL "https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.2.1%2Bcu118.zip")
+    if (ENABLE_CXX11_ABI)
+      set(LIBTORCH_URL "https://download.pytorch.org/libtorch/cu118/libtorch-cxx11-abi-shared-with-deps-2.2.1%2Bcu118.zip")
+    else()
+      set(LIBTORCH_URL "https://download.pytorch.org/libtorch/cu118/libtorch-shared-with-deps-2.2.1%2Bcu118.zip")
+    endif()
     message(STATUS "LIBTORCH_ROOT not found, downloading and using libtorch 2.2.1 for cuda ${CUDA_VERSION}")
   else()
     # error out if cuda version is not supported

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 
 option(USE_CCACHE "Attempt using CCache to wrap the compilation" OFF)
-option(ENABLE_CXX11_ABI "Use the new C++-11 ABI, which is not backwards compatible." OFF)
+option(ENABLE_CXX11_ABI "Use the new C++-11 ABI, which is not backwards compatible." ON)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/setup.py
+++ b/setup.py
@@ -166,12 +166,12 @@ setup(
     version="0.0.5",
     description="A high-performance inference system for large language models.",
     long_description="",
-    ext_modules=[CMakeExtension("scalellm")],
+    ext_modules=[CMakeExtension("gen_py_wrappers")],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
     extras_require={"test": ["pytest>=6.0"]},
     package_data={
-        "gen_py_wrappers": scalellm_package_data,
+        "scalellm": scalellm_package_data,
     },
     python_requires=">=3.10",
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ import os
 import re
 import subprocess
 import sys
-import torch
 from pathlib import Path
 
 from setuptools import Extension, setup

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,25 @@ import os
 import re
 import subprocess
 import sys
+import torch
 from pathlib import Path
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
+
+def use_cxx11_abi():
+    try:
+        import torch
+        return torch._C._GLIBCXX_USE_CXX11_ABI
+    except ImportError:
+        return False
+    
+def get_torch_root():
+    try:
+        import torch
+        return str(Path(torch.__file__).parent)
+    except ImportError:
+        return None
 
 # Convert distutils Windows platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {
@@ -99,6 +114,12 @@ class CMakeBuild(build_ext):
             archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
             if archs:
                 cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
+                
+        # check if torch binary is built with cxx11 abi
+        if use_cxx11_abi():
+            cmake_args += ["-DENABLE_CXX11_ABI=ON"]
+        else:
+            cmake_args += ["-DENABLE_CXX11_ABI=OFF"]
 
         # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
         # across all generators.
@@ -114,13 +135,23 @@ class CMakeBuild(build_ext):
         if not build_temp.exists():
             build_temp.mkdir(parents=True)
 
-        build_args += [f"-j32"]
+        # config based on cpu core
+        cpu_cores = os.cpu_count()
+        build_args += [f"-j{cpu_cores}"]
+        
+        env = os.environ.copy()
+        LIBTORCH_ROOT = get_torch_root()
+        if LIBTORCH_ROOT is not None:
+            env["LIBTORCH_ROOT"] = LIBTORCH_ROOT
 
         subprocess.run(
-            ["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True
+            ["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True, env=env
         )
+        
+        # add build target to speed up the build process
+        build_args += ["--target", ext.name]
         subprocess.run(
-            ["cmake", "--build", ".", *build_args], cwd=build_temp, check=True
+            ["cmake", "--build", ".", *build_args], cwd=build_temp, check=True, env=env
         )
 
 # The information here can also be placed in setup.cfg - better separation of
@@ -140,7 +171,7 @@ setup(
     zip_safe=False,
     extras_require={"test": ["pytest>=6.0"]},
     package_data={
-        "scalellm": scalellm_package_data,
+        "gen_py_wrappers": scalellm_package_data,
     },
     python_requires=">=3.10",
 )


### PR DESCRIPTION
as title, this diff includes:
1> pass cxx11_abi status from setup.py to cmake to decide which vcpkg to download.
2> pass torch root from conda virtual env if present