### PR TITLE
[perf] enabled speed up for gpa and mqa decoding.

### DIFF
--- a/src/kernels/flash_attn/flash_api.h
+++ b/src/kernels/flash_attn/flash_api.h
@@ -24,6 +24,7 @@ mha_varlen_fwd(at::Tensor& out,             // [n_tokens, n_heads, head_dim]
                int max_seqlen_q,      // max sequence length for Q
                int max_seqlen_k,      // max sequence length for K/V
                float softmax_scale,
+               bool is_causal,
                int window_size_left,
                int window_size_right,
                int num_splits); // 0: auto, 1: no split, >1: split key/value into num_splits parts

--- a/src/layers/attention/flash_attn_handler.cpp
+++ b/src/layers/attention/flash_attn_handler.cpp
@@ -31,9 +31,10 @@ void FlashAttnHandler::batch_prefill(
                  input_params.q_max_seq_len,
                  input_params.kv_max_seq_len,
                  /*softmax_scale=*/scale_,
+                 /*is_causal=*/true,
                  /*window_size_left=*/-1,
-                 /*window_size_right=*/0,
-                 /*num_splits=*/1);
+                 /*window_size_right=*/-1,
+                 /*num_splits=*/0);
 }
 
 // batch decode for attention, optimized for decode stage
@@ -43,8 +44,6 @@ void FlashAttnHandler::batch_decode(
     const KVCache& kv_cache,              // where to retrieval key and value
     const InputParameters& input_params,  // input paras used for attention
     torch::Tensor& output) {
-  // TODO: enable split once the core dump issue fixed
-  const int32_t num_splits = 1;
   auto [key_cache, value_cache] = kv_cache.get_kv_cache();
 
   mha_varlen_fwd(output,
@@ -58,9 +57,10 @@ void FlashAttnHandler::batch_decode(
                  input_params.q_max_seq_len,
                  input_params.kv_max_seq_len,
                  scale_,
+                 /*is_causal=*/true,
                  /*window_size_left=*/-1,
-                 /*window_size_right=*/0,
-                 num_splits);
+                 /*window_size_right=*/-1,
+                 /*num_splits=*/0);
 }
 
 // append key and value to kv_cache


### PR DESCRIPTION
In scenarios involving GPA and MQA decoding, particularly when q_seq_len = 1 and n_heads > n_kv_heads, transposing the query shape would optimize efficiency significantly. 
```
query: [batch_size, n_heads, head_dim] 
      => [batch_size, n_kv_heads, n_groups, head_dim]
      => [batch_size, n_groups, n_kv_heads, head_dim]
      => [batch_size*n_groups, n_kv_heads, head_dim]
```