### PR TITLE
[refactor] avoid name conflict with torch::indexing::Slice

### DIFF
--- a/src/engine/utils.cpp
+++ b/src/engine/utils.cpp
@@ -207,7 +207,6 @@ void Utils::prepare_inputs(const std::vector<Sequence*>& batch,
         std::max(max_block_table_len, static_cast<int32_t>(blocks.size()));
   }
 
-  using torch::indexing::Slice;
   // construct two-dimensional tensors for token ids and counts
   auto token_ids = create_2d_tensor(token_ids_vec,
                                     max_unique_tokens,

--- a/src/engine/worker.cpp
+++ b/src/engine/worker.cpp
@@ -381,7 +381,6 @@ void Worker::capture_graph() {
                                   &flatten_positions,
                                   &input_params);
     auto graph_runner = new CudaGraphRunner(model_.get());
-    using namespace torch::indexing;
     graph_runner->capture(
         flatten_token_ids,
         flatten_positions,

--- a/src/layers/attention/ref_handler.cpp
+++ b/src/layers/attention/ref_handler.cpp
@@ -7,7 +7,7 @@
 #include "models/input_parameters.h"
 
 namespace llm {
-using torch::indexing::Slice;
+using ISlice = torch::indexing::Slice;
 
 namespace {
 constexpr float negative_infinity = -std::numeric_limits<float>::infinity();
@@ -110,7 +110,7 @@ void varlen_masked_self_attention(
 
     const auto attn =
         masked_self_attention(_query, _key, _value, bias, mask, scale);
-    output.index_put_({Slice(q_start, q_end), Slice(), Slice()}, attn);
+    output.index_put_({ISlice(q_start, q_end), ISlice(), ISlice()}, attn);
   }
 }
 
@@ -125,12 +125,8 @@ RefHandler::RefHandler(float scale,
                        const torch::TensorOptions& options)
     : scale_(scale) {
   // register rotary positional embedding
-  pos_emb_ = RotaryEmbedding(rotary_dim,
-                             max_position,
-                             rope_scaling,
-                             rope_theta,
-                             interleaved,
-                             options);
+  pos_emb_ = RotaryEmbedding(
+      rotary_dim, max_position, rope_scaling, rope_theta, interleaved, options);
 }
 
 RefHandler::RefHandler(float scale, torch::optional<torch::Tensor> alibi_slopes)

--- a/src/layers/pos_embedding.cpp
+++ b/src/layers/pos_embedding.cpp
@@ -13,12 +13,12 @@ namespace llm {
 
 namespace {
 using torch::indexing::None;
-using torch::indexing::Slice;
+using ISlice = torch::indexing::Slice;
 
 // [1, 2, 3, 4] => [-2, 1, -4, 3]
 inline torch::Tensor rotate_every_two(const torch::Tensor& x) {
-  auto x1 = x.index({Slice(), Slice(), Slice(0, None, 2)});
-  auto x2 = x.index({Slice(), Slice(), Slice(1, None, 2)});
+  auto x1 = x.index({ISlice(), ISlice(), ISlice(0, None, 2)});
+  auto x2 = x.index({ISlice(), ISlice(), ISlice(1, None, 2)});
   return torch::stack({-x2, x1}, /*dim=*/-1).flatten(/*start_dim=*/-2);
 }
 
@@ -153,10 +153,10 @@ std::tuple<torch::Tensor, torch::Tensor> RotaryEmbeddingGeneric::forward(
     const torch::Tensor& positions  // [num_tokens]
 ) const {
   DCHECK_GE(query.size(-1), rotary_dim_);
-  auto query_rotary = query.index({"...", Slice(0, rotary_dim_)});
-  auto query_pass = query.index({"...", Slice(rotary_dim_, None)});
-  auto key_rotary = key.index({"...", Slice(0, rotary_dim_)});
-  auto key_pass = key.index({"...", Slice(rotary_dim_, None)});
+  auto query_rotary = query.index({"...", ISlice(0, rotary_dim_)});
+  auto query_pass = query.index({"...", ISlice(rotary_dim_, None)});
+  auto key_rotary = key.index({"...", ISlice(0, rotary_dim_)});
+  auto key_pass = key.index({"...", ISlice(rotary_dim_, None)});
 
   namespace F = torch::nn::functional;
   auto cos_sin = F::embedding(positions, cos_sin_cache_);

--- a/src/layers/pos_embedding_test.cpp
+++ b/src/layers/pos_embedding_test.cpp
@@ -8,7 +8,7 @@
 namespace llm {
 namespace {
 using torch::indexing::None;
-using torch::indexing::Slice;
+using ISlice = torch::indexing::Slice;
 
 // Rotary code ported from llama repo, which is used as disired output
 torch::Tensor precompute_freqs_cis(int64_t dim,
@@ -55,8 +55,8 @@ std::tuple<torch::Tensor, torch::Tensor> apply_rotary_emb(
 
 // [1, 2, 3, 4, 5, 6] => [1, 3, 5, 2, 4, 6]
 inline torch::Tensor interleaved_to_half(const torch::Tensor& x) {
-  auto x1 = x.index({Slice(), Slice(), Slice(0, None, 2)});
-  auto x2 = x.index({Slice(), Slice(), Slice(1, None, 2)});
+  auto x1 = x.index({ISlice(), ISlice(), ISlice(0, None, 2)});
+  auto x2 = x.index({ISlice(), ISlice(), ISlice(1, None, 2)});
   return torch::cat({x1, x2}, /*dim=*/-1);
 }
 

--- a/src/memory/kv_cache.cpp
+++ b/src/memory/kv_cache.cpp
@@ -11,7 +11,7 @@
 #include "kernels/kv_cache_kernels.h"
 
 namespace llm {
-using torch::indexing::Slice;
+using ISlice = torch::indexing::Slice;
 
 // [num_blocks, block_size, num_kv_heads, head_dim]
 KVCache::KVCache(torch::Tensor key_cache, torch::Tensor value_cache)
@@ -50,9 +50,9 @@ void KVCache::set_kv_cache_slow(const torch::Tensor& slot_ids,
     const auto block_offset = slot_id % block_size_;
 
     // key_cache_[block_id, block_offset, :, :] = key
-    key_cache_.index_put_({block_id, block_offset, Slice(), Slice()}, keys[i]);
+    key_cache_.index_put_({block_id, block_offset, ISlice(), ISlice()}, keys[i]);
     // value_cache_[block_id, block_offset, :, :] = value
-    value_cache_.index_put_({block_id, block_offset, Slice(), Slice()},
+    value_cache_.index_put_({block_id, block_offset, ISlice(), ISlice()},
                             values[i]);
   }
 }
@@ -93,11 +93,11 @@ std::tuple<torch::Tensor, torch::Tensor> KVCache::get_kv_cache(
     const int64_t block_offset = slot_id % block_size_;
     // key = key_cache_[block_id, block_offset, :, :]
     const auto key =
-        key_cache_.index({block_id, block_offset, Slice(), Slice()});
+        key_cache_.index({block_id, block_offset, ISlice(), ISlice()});
     keys.push_back(key.reshape({num_kv_heads_, head_size_}));
     // value = value_cache_[block_id, block_offset, :, :]
     const auto value =
-        value_cache_.index({block_id, block_offset, Slice(), Slice()});
+        value_cache_.index({block_id, block_offset, ISlice(), ISlice()});
     values.push_back(value);
   }
   return std::make_tuple(torch::stack(keys), torch::stack(values));
@@ -144,11 +144,11 @@ std::tuple<torch::Tensor, torch::Tensor> KVCache::get_kv_cache(
 
       // key = key_cache_[block_id, block_offset, :, :]
       const auto key =
-          key_cache_.index({block_id, block_offset, Slice(), Slice()});
+          key_cache_.index({block_id, block_offset, ISlice(), ISlice()});
       keys.push_back(key.reshape({num_kv_heads_, head_size_}));
       // value = value_cache_[block_id, block_offset, :, :]
       const auto value =
-          value_cache_.index({block_id, block_offset, Slice(), Slice()});
+          value_cache_.index({block_id, block_offset, ISlice(), ISlice()});
       values.push_back(value);
     }
   }

--- a/src/memory/kv_cache_test.cpp
+++ b/src/memory/kv_cache_test.cpp
@@ -80,14 +80,14 @@ TEST(KVCacheTest, Random) {
   KVCache kv_cache(key_cache, value_cache);
 
   for (int32_t i = 0; i < 10000; ++i) {
-    using torch::indexing::Slice;
+    using ISlice = torch::indexing::Slice;
 
     const int sample_size = std::min(num_blocks * block_size, 10);
     const int num_slots = i % sample_size + 1;
     torch::Tensor slot_ids =
         torch::randperm(num_blocks * block_size,
                         torch::dtype(torch::kInt).device(device))
-            .index({Slice(0, num_slots)});
+            .index({ISlice(0, num_slots)});
 
     torch::Tensor keys =
         torch::rand({num_slots, num_kv_heads, head_dim}, torch::device(device));

--- a/src/models/huggingface/mpt.h
+++ b/src/models/huggingface/mpt.h
@@ -368,9 +368,10 @@ class MPTModelImpl : public torch::nn::Module {
     m.mul_(bias_max / next_power_of_2);
     auto slopes = 1.0f / torch::pow(2, m);
     if (next_power_of_2 != n_heads) {
-      using namespace torch::indexing;
-      slopes = torch::cat({slopes.index({Slice(1, None, 2)}),
-                           slopes.index({Slice(None, None, 2)})});
+      using ISlice = torch::indexing::Slice;
+      using torch::indexing::None;
+      slopes = torch::cat({slopes.index({ISlice(1, None, 2)}),
+                           slopes.index({ISlice(None, None, 2)})});
     }
     if (parallel_args.world_size() > 1) {
       slopes = slopes.chunk(/*chunks=*/parallel_args.world_size(),


### PR DESCRIPTION
using ISlice = torch::indexing::Slice to avoid name conflict.