### PR TITLE
[feat] added prompt blocks sharing across n sequences

### DIFF
--- a/src/memory/block_manager.cpp
+++ b/src/memory/block_manager.cpp
@@ -77,14 +77,7 @@ void BlockManager::release_blocks_for(std::vector<Sequence*>& sequences) {
 
 void BlockManager::release_blocks_for(Sequence* sequence) {
   DCHECK(sequence != nullptr);
-
-  if (FLAGS_enable_prefix_cache) {
-    // only insert tokens in kv cache to the prefix cache
-    const auto tokens_ids = sequence->tokens_in_kv_cache();
-    const auto blocks = sequence->blocks();
-    // Add the kv cache to the prefix cache
-    prefix_cache_.insert(tokens_ids, blocks);
-  }
+  cache_blocks_for(sequence);
   // release the blocks after prefix cache insertion
   sequence->release_blocks();
 }
@@ -124,6 +117,16 @@ void BlockManager::allocate_shared_blocks_for(Sequence* sequence) {
     const auto tokens_ids = sequence->token_ids();
     std::vector<Block> shared_blocks = prefix_cache_.match(tokens_ids);
     sequence->append_shared_blocks(shared_blocks);
+  }
+}
+
+void BlockManager::cache_blocks_for(Sequence* sequence) {
+  if (FLAGS_enable_prefix_cache) {
+    // only insert tokens in kv cache to the prefix cache
+    const auto tokens_ids = sequence->tokens_in_kv_cache();
+    const auto blocks = sequence->blocks();
+    // Add the kv cache to the prefix cache
+    prefix_cache_.insert(tokens_ids, blocks);
   }
 }
 

--- a/src/memory/block_manager.h
+++ b/src/memory/block_manager.h
@@ -30,6 +30,9 @@ class BlockManager final {
   // try to share blocks among sequences with the same prefix
   void allocate_shared_blocks_for(Sequence* sequence);
 
+  // cache the blocks for the sequence
+  void cache_blocks_for(Sequence* sequence);
+
  private:
   // check if block allocator has enough slots, if not, try to evict some blocks
   // from the prefix cache

--- a/src/request/request.cpp
+++ b/src/request/request.cpp
@@ -15,29 +15,44 @@ namespace llm {
 
 Request::Request(const std::string& id,
                  const std::string_view& prompt,
+                 size_t n,
                  const std::vector<int32_t>& prompt_tokens)
     : id(id),
       prompt(prompt),
+      num_seqs(n),
       created_time(absl::ToUnixSeconds(absl::Now())),
       prompt_tokens(prompt_tokens) {}
 
 Request::Request(const std::string& id,
                  const std::vector<int32_t>& prompt_tokens)
-    : Request(id, "", prompt_tokens) {}
+    : Request(id, /*prompt=*/"", /*n=*/1, prompt_tokens) {}
 
-void Request::add_sequence(OnStream on_stream) {
+void Request::add_sequence() {
+  OnDelta on_delta = nullptr;
+  
   if (stream) {
-    CHECK(on_stream) << "on_stream should not be null if stream is true";
+    CHECK(on_stream_delta);
+    on_delta = [this, index = sequences.size(), first_message = true](
+                   const std::string& delta, FinishReason reason) mutable {
+      bool ret = this->on_stream_delta(index, first_message, delta, reason);
+      first_message = false;
+      return ret;
+    };
   }
   sequences.emplace_back(this->prompt,
                          this->prompt_tokens,
                          this->sampling_param,
                          this->stopping_criteria,
                          this->echo,
-                         on_stream);
+                         on_delta);
 }
 
 bool Request::is_finished() const {
+  // still need to generate more sequences
+  if (sequences.size() < num_seqs) {
+    return false;
+  }
+
   for (const auto& seq : sequences) {
     if (!seq.is_finished()) {
       return false;
@@ -45,4 +60,23 @@ bool Request::is_finished() const {
   }
   return true;
 }
+
+bool Request::should_expand_sequences() const {
+  if (sequences.size() < num_seqs) {
+    CHECK(!sequences.empty());
+    const auto& first_sequence = sequences.front();
+    // if all prompt tokens are in kv cache, then expand
+    return first_sequence.num_tokens_in_kv_cache() >=
+           first_sequence.num_tokens();
+  }
+  return false;
+}
+
+void Request::expand_sequences() {
+  CHECK(should_expand_sequences()) << "should_expand() should return true";
+  while (sequences.size() < num_seqs) {
+    add_sequence();
+  }
+}
+
 }  // namespace llm

--- a/src/request/request.cpp
+++ b/src/request/request.cpp
@@ -67,13 +67,12 @@ bool Request::should_expand_sequences() const {
     const auto& first_sequence = sequences.front();
     // if all prompt tokens are in kv cache, then expand
     return first_sequence.num_tokens_in_kv_cache() >=
-           first_sequence.num_tokens();
+           first_sequence.num_prompt_tokens();
   }
   return false;
 }
 
 void Request::expand_sequences() {
-  CHECK(should_expand_sequences()) << "should_expand() should return true";
   while (sequences.size() < num_seqs) {
     add_sequence();
   }

--- a/src/request/request.cpp
+++ b/src/request/request.cpp
@@ -29,7 +29,7 @@ Request::Request(const std::string& id,
 
 void Request::add_sequence() {
   OnDelta on_delta = nullptr;
-  
+
   if (stream) {
     CHECK(on_stream_delta);
     on_delta = [this, index = sequences.size(), first_message = true](

--- a/src/request/sequence.h
+++ b/src/request/sequence.h
@@ -24,7 +24,7 @@ enum class FinishReason {
   FUNCTION_CALL,
 };
 
-using OnStream =
+using OnDelta =
     std::function<bool(const std::string& delta, FinishReason reason)>;
 
 // Since the sequence is shared between LLM and SSM for speculative decoding,
@@ -49,14 +49,14 @@ class Sequence final {
            const SamplingParameter& sampling_param,
            const StoppingCriteria& stopping_criteria,
            bool echo,
-           OnStream on_stream);
+           OnDelta on_delta);
 
   Sequence(const std::string_view& prompt,
            const std::vector<int32_t>& token_ids,
            const SamplingParameter& sampling_param,
            const StoppingCriteria& stopping_criteria,
            bool echo,
-           OnStream on_stream);
+           OnDelta on_delta);
 
   // get the id of the sequence
   int64_t id() const { return id_; }
@@ -129,7 +129,7 @@ class Sequence final {
   std::string decode_delta_text(size_t end, const Tokenizer& tokenizer);
 
   // check if streaming is enabled
-  bool is_streaming() const { return on_stream_ != nullptr; }
+  bool is_streaming() const { return on_delta_ != nullptr; }
 
   // stream the delta text to the client
   void stream_delta(const std::string& delta, FinishReason reason);
@@ -211,7 +211,7 @@ class Sequence final {
   size_t output_offset_ = 0;
 
   // function to call when new tokens are generated. (only for streaming)
-  OnStream on_stream_;
+  OnDelta on_delta_;
 
   // TODO: Add logits results.
 

--- a/src/scheduler/continuous_scheduler.cpp
+++ b/src/scheduler/continuous_scheduler.cpp
@@ -56,7 +56,7 @@ ContinuousScheduler::~ContinuousScheduler() {
 bool ContinuousScheduler::schedule(std::unique_ptr<Request>& request) {
   CHECK(request != nullptr);
   CHECK(!request->sequences.empty());
-  
+
   if (request_queue_.write(request.get())) {
     // take over the ownership of the request
     request.release();


### PR DESCRIPTION
When n is greater than 1, only one sequence would be added into request, letting the scheduler expand the rest to avoid redundant computations.