### PR TITLE
[feat] enable speculative decoding for simple server

### DIFF
--- a/src/engine/batch.cpp
+++ b/src/engine/batch.cpp
@@ -88,7 +88,7 @@ ModelInput Batch::prepare_model_input() {
   const int32_t num_sequences = static_cast<int32_t>(sequences_.size());
   for (int32_t i = 0; i < num_sequences; ++i) {
     auto* sequence = sequences_[i];
-    CHECK(!sequence->is_finished());
+    // CHECK(!sequence->is_finished());
 
     empty_kv_cache = empty_kv_cache && (sequence->kv_cache_size() == 0);
 

--- a/src/engine/batch.cpp
+++ b/src/engine/batch.cpp
@@ -4,6 +4,7 @@
 
 #include <vector>
 
+#include "common/slice.h"
 #include "models/parameters.h"
 #include "request/sequence.h"
 
@@ -224,15 +225,10 @@ ModelInput Batch::prepare_model_input() {
   return model_inputs;
 }
 
-ModelInput Batch::prepare_model_validate_input() {
-  LOG(FATAL) << "Not implemented";
-  return {};
-}
-
-void Batch::process_model_output(const ModelOutput& model_output) {
+void Batch::process_sample_output(const SampleOutput& sample_output) {
   // it is possible that the model output is empty for prefill sequences
-  if (model_output.sample_output.next_tokens.defined()) {
-    const auto& next_tokens = model_output.sample_output.next_tokens.cpu();
+  if (sample_output.next_tokens.defined()) {
+    const auto& next_tokens = sample_output.next_tokens.cpu();
     const int64_t num_seqs = next_tokens.numel();
     int64_t output_idx = 0;
     for (auto* seq : sequences_) {
@@ -243,15 +239,33 @@ void Batch::process_model_output(const ModelOutput& model_output) {
       CHECK_LT(output_idx, num_seqs);
 
       // add the next token to sequence
-      const int32_t next_token_id = next_tokens[output_idx++].item<int32_t>();
+      const int32_t next_token_id =
+          static_cast<int32_t>(next_tokens[output_idx++].item<int64_t>());
       seq->append_new_token_id(next_token_id);
     }
     CHECK_EQ(output_idx, num_seqs);
   }
 }
 
-void Batch::process_model_validate_output(const ModelOutput& model_output) {
-  LOG(FATAL) << "Not implemented";
+void Batch::process_validate_output(const torch::Tensor& accepted_ids) {
+  const auto& token_ids = accepted_ids.cpu();
+  const int64_t num_seqs = accepted_ids.size(0);
+  int64_t output_idx = 0;
+  for (auto* seq : sequences_) {
+    if (seq->is_prefill_stage()) {
+      // no sampling for prefill sequences
+      continue;
+    }
+    CHECK_LT(output_idx, num_seqs);
+
+    const auto ids = token_ids[output_idx++];
+    const Slice<int64_t> accepted_token_ids = {
+        ids.data_ptr<int64_t>(), static_cast<size_t>(ids.numel())};
+
+    // validate the draft tokens with accepted tokens
+    seq->validate_token_ids(accepted_token_ids);
+  }
+  CHECK_EQ(output_idx, num_seqs);
 }
 
 void Batch::set_engine_type(EngineType engine_type) {

--- a/src/engine/batch.h
+++ b/src/engine/batch.h
@@ -47,14 +47,11 @@ class Batch {
   // prepare inputs for the batch, a stateful operation
   ModelInput prepare_model_input();
 
-  // TODO: do we really need a sperate function for validate?
-  ModelInput prepare_model_validate_input();
+  // process the sample output for each sequence
+  void process_sample_output(const SampleOutput& sample_output);
 
-  // process the model output for each sequence
-  void process_model_output(const ModelOutput& model_output);
-
-  // process the model output for each sequence in validate mode
-  void process_model_validate_output(const ModelOutput& model_output);
+  // process the accepted output for each sequence
+  void process_validate_output(const torch::Tensor& accepted_ids);
 
   // set the engine type for the batch
   void set_engine_type(EngineType engine_type);

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -2,7 +2,6 @@
 
 #include "batch.h"
 #include "models/model_args.h"
-#include "quantization/quant_args.h"
 #include "tokenizer/tokenizer.h"
 #include "tokenizer/tokenizer_args.h"
 
@@ -14,20 +13,18 @@ class Engine {
   virtual ~Engine() = default;
 
   // execute the model with the given batch, results are stored in the batch
-  virtual void execute_model(Batch& batch) = 0;
-
-  // validate multiple speculative tokens when use speculative decoding
-  virtual void validate(Batch& batch) = 0;
+  virtual ModelOutput execute_model(Batch& batch) = 0;
 
   // return a clone of the tokenizer
   virtual std::unique_ptr<Tokenizer> tokenizer() const = 0;
 
+  // return the block manager
   virtual BlockManager* block_manager() const = 0;
 
+  // return the model args
   virtual const ModelArgs& model_args() const = 0;
 
-  virtual const QuantArgs& quant_args() const = 0;
-
+  // return the tokenizer args
   virtual const TokenizerArgs& tokenizer_args() const = 0;
 };
 

--- a/src/engine/llm_engine.h
+++ b/src/engine/llm_engine.h
@@ -50,7 +50,7 @@ class LLMEngine : public Engine {
 
   // initialize the engine with the given model weights
   bool init(const std::string& model_weights_path);
-  
+
   const QuantArgs& quant_args() const { return quant_args_; }
 
   bool init_model(const std::string& model_weights_path);
@@ -65,6 +65,7 @@ class LLMEngine : public Engine {
 
   // returns the number of kv cache blocks from the given cache size in bytes
   int64_t calculate_kv_cache_blocks(int64_t cache_size_in_bytes) const;
+
  private:
   bool warmup_model();
 

--- a/src/engine/parameters.h
+++ b/src/engine/parameters.h
@@ -23,6 +23,9 @@ struct ModelInput {
 // output for the model that encapsulates all the necessary
 // output information.
 struct ModelOutput {
+  // sample carried over from input, used for speculative decoding
+  std::vector<bool> do_sample;
+
   // output of sampling
   SampleOutput sample_output;
 

--- a/src/engine/worker.cpp
+++ b/src/engine/worker.cpp
@@ -228,12 +228,6 @@ ModelOutput Worker::execute_model(const ModelInput& inputs) {
   return output;
 }
 
-ModelOutput Worker::validate(const ModelInput& inputs) {
-  LOG(FATAL) << "Not implemented.";
-  ModelOutput output_params;
-  return output_params;
-}
-
 folly::SemiFuture<std::tuple<int64_t, int64_t>>
 Worker::profile_device_memory_async(
     torch::Tensor flatten_tokens,     // [num_tokens]
@@ -261,18 +255,6 @@ folly::SemiFuture<ModelOutput> Worker::execute_model_async(
       [this, inputs = inputs, promise = std::move(promise)]() mutable {
         // run the model on the given input in working thread
         const auto output = this->execute_model(inputs);
-        promise.setValue(output);
-      });
-  return future;
-}
-
-folly::SemiFuture<ModelOutput> Worker::validate_async(
-    const ModelInput& inputs) {
-  folly::Promise<ModelOutput> promise;
-  auto future = promise.getSemiFuture();
-  threadpool_.schedule(
-      [this, inputs = inputs, promise = std::move(promise)]() mutable {
-        const auto output = this->validate(inputs);
         promise.setValue(output);
       });
   return future;

--- a/src/engine/worker.h
+++ b/src/engine/worker.h
@@ -47,9 +47,6 @@ class Worker final {
 
   bool warmup_model(bool enable_cudagraph);
 
-  // TODO: implement this
-  ModelOutput validate(const ModelInput& inputs);
-
   // initialize model, cache manager. async call
   folly::SemiFuture<bool> init_model_async(torch::ScalarType dtype,
                                            const ModelArgs& args,
@@ -72,8 +69,6 @@ class Worker final {
   // Run the model on the given input. async call
   // the future returns a successfull status with no meaningful value
   folly::SemiFuture<ModelOutput> execute_model_async(const ModelInput& inputs);
-
-  folly::SemiFuture<ModelOutput> validate_async(const ModelInput& inputs);
 
   folly::SemiFuture<bool> warmup_model_async(bool enable_cudagraph);
 

--- a/src/handlers/chat_handler.cpp
+++ b/src/handlers/chat_handler.cpp
@@ -193,10 +193,11 @@ std::unique_ptr<Request> grpc_request_to_request(ChatCallData* call_data,
     LOG(ERROR) << "Failed to encode prompt: " << prompt.value();
     return nullptr;
   }
-  if (prompt_tokens.size() > max_context_len) {
+  if (prompt_tokens.size() >= max_context_len) {
     call_data->finish_with_error(grpc::StatusCode::INVALID_ARGUMENT,
                                  "Prompt is too long");
-    LOG(ERROR) << "Prompt is too long: " << prompt_tokens.size();
+    LOG(ERROR) << "Prompt is too long, prompt_len:" << prompt_tokens.size()
+               << ", max_context_len: " << max_context_len;
     return nullptr;
   }
 

--- a/src/handlers/chat_handler.cpp
+++ b/src/handlers/chat_handler.cpp
@@ -236,6 +236,7 @@ std::unique_ptr<Request> grpc_request_to_request(ChatCallData* call_data,
     max_tokens = std::min(max_tokens, kDefaultMaxTokens);
   }
   stopping_criteria.max_tokens = max_tokens;
+  stopping_criteria.max_context_length = model_args.max_position_embeddings();
   // stopping_criteria.ignore_eos_token = false;
   stopping_criteria.eos_token_id = model_args.eos_token_id();
 

--- a/src/handlers/completion_handler.cpp
+++ b/src/handlers/completion_handler.cpp
@@ -219,6 +219,7 @@ std::unique_ptr<Request> grpc_request_to_request(CompletionCallData* call_data,
     max_tokens = std::min(max_tokens, kDefaultMaxTokens);
   }
   stopping_criteria.max_tokens = max_tokens;
+  stopping_criteria.max_context_length = model_args.max_position_embeddings();
   // stopping_criteria.ignore_eos_token = false;
   stopping_criteria.eos_token_id = model_args.eos_token_id();
 

--- a/src/request/sequence.cpp
+++ b/src/request/sequence.cpp
@@ -79,7 +79,7 @@ void Sequence::append_new_token_id(int32_t next_token_id) {
   finish_status_invalidated_ = true;
 }
 
-void Sequence::validate_token_ids(const Slice<int32_t>& accpeted_token_ids) {
+void Sequence::validate_token_ids(const Slice<int64_t>& accpeted_token_ids) {
   const size_t len = accpeted_token_ids.size();
   CHECK_GT(num_tokens_, len) << "accepted tokens exceed the sequence length";
 
@@ -88,7 +88,7 @@ void Sequence::validate_token_ids(const Slice<int32_t>& accpeted_token_ids) {
   size_t i = 0;
   for (; i < len; ++i) {
     const int32_t draft_token_id = token_ids_[start_idx + i];
-    const int32_t target_token_id = accpeted_token_ids[i];
+    const int32_t target_token_id = static_cast<int32_t>(accpeted_token_ids[i]);
     // stop at the first mismatch
     if (target_token_id != draft_token_id) {
       // overwrite the token id with the accepted token id

--- a/src/request/sequence.cpp
+++ b/src/request/sequence.cpp
@@ -52,7 +52,8 @@ Sequence::Sequence(const std::string_view& prompt,
 
   // allocate space for the token ids and add the prompt tokens
   const size_t max_tokens = stopping_criteria.max_tokens;
-  token_ids_.resize(max_tokens + prompt_token_ids.size());
+  // TODO: boundary check for max_tokens for speculative decoding
+  token_ids_.resize(max_tokens + prompt_token_ids.size() + 10 /*buffer for speculative decoding*/);
   for (const auto token_id : prompt_token_ids) {
     token_ids_[num_tokens_++] = token_id;
     token_to_count_map_[token_id]++;

--- a/src/request/sequence.h
+++ b/src/request/sequence.h
@@ -113,7 +113,9 @@ class Sequence final {
   void append_new_token_id(int32_t next_token_id);
 
   // validate draft tokens with accepted tokens for speculative decoding
-  void validate_token_ids(const Slice<int32_t>& accpeted_token_ids);
+  // N.B. take int64_t as input to be compatible with torch::Tensor to avoid
+  // copy
+  void validate_token_ids(const Slice<int64_t>& accpeted_token_ids);
 
   // add new cache blocks
   void append_blocks(const std::vector<Block>& new_blocks);

--- a/src/request/stopping_criteria.h
+++ b/src/request/stopping_criteria.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -24,6 +23,9 @@ struct StoppingCriteria {
 
   // stop sequences
   std::vector<std::vector<int32_t>> stop_sequences;
+
+  // max context length
+  size_t max_context_length = 0;
 };
 
 }  // namespace llm

--- a/src/sampling/parameters.h
+++ b/src/sampling/parameters.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <torch/torch.h>
+
 #include <cstdint>
 #include <vector>
 
@@ -91,9 +92,12 @@ struct SamplingParameters {
 struct SampleOutput {
   // [num_seq] LongTensor
   torch::Tensor next_tokens;
-  
+
   // [num_seq] FloatTensor
-  // torch::Tensor next_logprobs;
+  torch::Tensor probs;
+
+  // [num_seq] FloatTensor
+  torch::Tensor logprobs;
 };
 
 }  // namespace llm

--- a/src/scheduler/CMakeLists.txt
+++ b/src/scheduler/CMakeLists.txt
@@ -19,6 +19,7 @@ cc_library(
   DEPS
     :request
     :engine
+    :speculative
     glog::glog
     Folly::folly
     absl::time

--- a/src/scheduler/continuous_scheduler.cpp
+++ b/src/scheduler/continuous_scheduler.cpp
@@ -14,9 +14,9 @@
 
 DEFINE_int32(max_tokens_per_batch, 1024, "max number of tokens per batch");
 DEFINE_int32(max_seqs_per_batch, 128, "max number of sequences per batch");
-DEFINE_int32(num_speculative_steps, 0, "number of speculative steps");
 
 DECLARE_bool(enable_prefix_cache);
+DECLARE_int32(num_speculative_steps);
 
 namespace llm {
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -49,6 +49,7 @@ cc_binary(
     simple.cpp
   DEPS
     :engine
+    :speculative
     torch
     absl::strings
     gflags::gflags

--- a/src/speculative/speculative_engine.cpp
+++ b/src/speculative/speculative_engine.cpp
@@ -9,7 +9,8 @@
 #include "rejection_sampler.h"
 
 DECLARE_int32(block_size);
-DEFINE_int32(num_speculative_steps, 0, "number of speculative steps");
+DECLARE_int32(num_speculative_steps);
+
 namespace llm {
 
 SpeculativeEngine::SpeculativeEngine(

--- a/src/speculative/speculative_engine.cpp
+++ b/src/speculative/speculative_engine.cpp
@@ -5,13 +5,29 @@
 
 #include <memory>
 
+#include "engine/parameters.h"
+#include "rejection_sampler.h"
+
+DECLARE_int32(block_size);
+DEFINE_int32(num_speculative_steps, 0, "number of speculative steps");
 namespace llm {
 
 SpeculativeEngine::SpeculativeEngine(
     const std::vector<torch::Device>& devices,
     const std::vector<torch::Device>& draft_devices) {
+  CHECK_GT(FLAGS_num_speculative_steps, 0) << "speculative steps should be > 0";
+
   engine_ = std::make_unique<LLMEngine>(devices);
   draft_engine_ = std::make_unique<LLMEngine>(draft_devices);
+
+  for (const auto& target : devices) {
+    for (const auto& draft : draft_devices) {
+      if (target == draft) {
+        share_device_ = true;
+        break;
+      }
+    }
+  }
 }
 
 bool SpeculativeEngine::init(const std::string& model_weights_path,
@@ -20,11 +36,11 @@ bool SpeculativeEngine::init(const std::string& model_weights_path,
     return false;
   }
 
-  // const int64_t kv_cache_size_in_bytes = profile_memory_for_kv_cache();
-  // if (!init_kv_cache(kv_cache_size_in_bytes)) {
-  //   LOG(ERROR) << "Failed to initialize kv cache";
-  //   return false;
-  // }
+  // init kv cache
+  if (!init_kv_cache()) {
+    return false;
+  }
+
   return true;
 }
 
@@ -37,20 +53,112 @@ bool SpeculativeEngine::init_model(
   if (!draft_engine_->init_model(draft_model_weights_path)) {
     return false;
   }
+
+  // TODO: check if the tokenizers are the same
+  // TODO: check if the max context length are the same
   return true;
 }
 
-bool SpeculativeEngine::init_kv_cache(int64_t cache_size_in_bytes) {
-  // TODO: share block allocation between engine and draft_engine
-  return false;
+bool SpeculativeEngine::init_kv_cache() {
+  // determine the kv cache size
+  int64_t n_blocks = 0;
+  const int64_t target_kv_cache_size = engine_->profile_memory_for_kv_cache();
+  const int64_t draft_kv_cache_size =
+      draft_engine_->profile_memory_for_kv_cache();
+
+  // check if llm and ssm are using same device
+  if (share_device_) {
+    // on the same device, use the smaller kv cache size
+    const int64_t kv_cache_size =
+        std::min(target_kv_cache_size, draft_kv_cache_size);
+    n_blocks = calculate_kv_cache_blocks(kv_cache_size);
+  } else {
+    // on different devices, use the smaller number of blocks
+    const int64_t target_blocks =
+        engine_->calculate_kv_cache_blocks(target_kv_cache_size);
+    const int64_t draft_blocks =
+        draft_engine_->calculate_kv_cache_blocks(draft_kv_cache_size);
+    n_blocks = std::min(target_blocks, draft_blocks);
+  }
+  CHECK_GT(n_blocks, 0) << "no memory for kv cache";
+  // init kv cache
+  return engine_->init_kv_cache(n_blocks) &&
+         draft_engine_->init_kv_cache(n_blocks);
 }
 
-void SpeculativeEngine::execute_model(Batch& batch) {
-  LOG(FATAL) << "Not implemented";
+ModelOutput SpeculativeEngine::execute_model(Batch& batch) {
+  // run the draft model to get proposals
+  std::vector<ModelOutput> draft_outputs;
+  batch.set_engine_type(EngineType::SSM);
+  for (size_t i = 0; i < FLAGS_num_speculative_steps; ++i) {
+    auto draft_output = draft_engine_->execute_model(batch);
+    // TODO: check if draft_output is valid/empty
+    draft_outputs.push_back(draft_output);
+  }
+
+  // run the target model to get the verification scores
+  batch.set_engine_type(EngineType::LLM);
+  ModelOutput output = engine_->execute_model(batch);
+
+  // verify the proposals with target and update the batch
+  validate(batch, draft_outputs, output);
+  return output;
 }
 
-void SpeculativeEngine::validate(Batch& batch) {
-  LOG(FATAL) << "Not implemented";
+void SpeculativeEngine::validate(Batch& batch,
+                                 const std::vector<ModelOutput>& draft_outputs,
+                                 const ModelOutput& target_output) {
+  const auto bonus_token_ids = target_output.sample_output.next_tokens;
+  if (!bonus_token_ids.defined()) {
+    // a pure prefill batch, no sampling needed
+    return;
+  }
+  auto num_speculative_tokens = target_output.logits.size(/*dim=*/-1);
+  CHECK_EQ(num_speculative_tokens, draft_outputs.size());
+
+  auto target_probs = torch::softmax(
+      target_output.logits, /*dim=*/-1, /*dtype=*/torch::kFloat32);
+  // filter out last column of target_probs
+  target_probs = target_probs.slice(
+      /*dim=*/-1, /*start=*/0, /*end=*/num_speculative_tokens - 1);
+
+  // prepare input for rejection sampling
+  std::vector<torch::Tensor> draft_token_ids_vec;
+  std::vector<torch::Tensor> draft_probs_vec;
+  for (const auto& draft_output : draft_outputs) {
+    draft_token_ids_vec.push_back(draft_output.sample_output.next_tokens);
+    draft_probs_vec.push_back(draft_output.sample_output.probs);
+  }
+
+  // concatenate the draft token ids and probs along the last dimension
+  const auto draft_token_ids =
+      torch::cat(draft_token_ids_vec, /*dim=*/-1).to(bonus_token_ids);
+  const auto draft_probs =
+      torch::cat(draft_probs_vec, /*dim=*/-1).to(target_probs);
+
+  auto rejection_sampler = std::make_unique<RejectionSampler>(
+      target_output.do_sample, target_probs.options());
+
+  // get the accepted tokens
+  auto accepted_tokens = rejection_sampler->forward(
+      draft_token_ids, draft_probs, target_probs, bonus_token_ids);
+
+  // update the batch with the accpeted tokens
+  batch.process_validate_output(accepted_tokens);
+}
+
+int64_t SpeculativeEngine::calculate_kv_cache_blocks(
+    int64_t cache_size_in_bytes) const {
+  CHECK_GT(cache_size_in_bytes, 0) << "no memory for kv cache";
+
+  // compute the kv cache slot size in bytes
+  const int64_t target_slot_size = engine_->kv_cache_slot_size_in_bytes();
+  const int64_t draft_slot_size = draft_engine_->kv_cache_slot_size_in_bytes();
+
+  // compute the number of blocks
+  const int64_t block_size_in_bytes =
+      FLAGS_block_size * (target_slot_size + draft_slot_size);
+  return cache_size_in_bytes / block_size_in_bytes;
 }
 
 }  // namespace llm


### PR DESCRIPTION
still have two issues: 
1> can't download both draft and target model in simple:
workaround would be one with name the other with path. for example:
```
/home/michael/code/ScaleLLM/build/src/server/simple --logtostderr --device=cuda:0 --model_name_or_path=baichuan-inc/Baichuan2-13B-Base --draft_model_name_or_path=/home/michael/.cache/huggingface/hub/models--baichuan-inc--Baichuan2-7B-Base/snapshots/f9d4d8dd2f7a3dbede3bda3b0cf0224e9272bbe5 --num_speculative_steps=3
```

2> rejection sampling result is not right