### PR TITLE
[refactor] add implicit conversion between slice and vector

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         # Tells ccache where to store its cache.
         CCACHE_DIR: ${{ github.workspace }}/.ccache
         # LIBTORCH_ROOT
-        # LIBTORCH_ROOT: ${{ github.workspace }}/../../../libtorch
+        LIBTORCH_ROOT: ${{ github.workspace }}/../../../libtorch
 
     steps:
     - name: Install toolkits

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         # Tells ccache where to store its cache.
         CCACHE_DIR: ${{ github.workspace }}/.ccache
         # LIBTORCH_ROOT
-        LIBTORCH_ROOT: ${{ github.workspace }}/../../../libtorch
+        # LIBTORCH_ROOT: ${{ github.workspace }}/../../../libtorch
 
     steps:
     - name: Install toolkits

--- a/src/common/slice.h
+++ b/src/common/slice.h
@@ -52,12 +52,25 @@ class Slice final {
     return {data_ + start, end - start};
   }
 
-  // convert to vector
-  std::vector<T> to_vector() const { return {data_, data_ + size_}; }
+  // it is safe to allow implicit conversion to vector
+  operator std::vector<T>() const { return {data_, data_ + size_}; }
 
  private:
   const T* data_ = nullptr;
   size_t size_ = 0;
 };
+
+// help comparison operators between slices and std::vector
+template <typename T>
+bool operator==(const Slice<T>& lhs, const std::vector<T>& rhs) {
+  return lhs.size() == rhs.size() &&
+         std::equal(lhs.begin(), lhs.end(), rhs.begin());
+}
+
+template <typename T>
+bool operator==(const std::vector<T>& lhs, const Slice<T>& rhs) {
+  return lhs.size() == rhs.size() &&
+         std::equal(lhs.begin(), lhs.end(), rhs.begin());
+}
 
 }  // namespace llm

--- a/src/request/sequence_test.cpp
+++ b/src/request/sequence_test.cpp
@@ -77,7 +77,7 @@ TEST(SequenceTest, EosTokenId) {
   EXPECT_EQ(sequence.num_tokens(), 4);
 
   std::vector<int32_t> desired_tokens = {1, 2, 4, eos_token_id};
-  EXPECT_EQ(sequence.token_ids().to_vector(), desired_tokens);
+  EXPECT_EQ(sequence.token_ids(), desired_tokens);
 }
 
 TEST(SequenceTest, StopTokenIds) {
@@ -119,7 +119,7 @@ TEST(SequenceTest, StopTokenIds) {
   EXPECT_EQ(sequence.num_generated_tokens(), 6);
   EXPECT_EQ(sequence.num_tokens(), 9);
   std::vector<int32_t> desired_tokens = {1, 2, 4, 3, 4, 3, 5, 6, 20};
-  EXPECT_EQ(sequence.token_ids().to_vector(), desired_tokens);
+  EXPECT_EQ(sequence.token_ids(), desired_tokens);
 }
 
 TEST(SequenceTest, StopSequences) {
@@ -161,7 +161,7 @@ TEST(SequenceTest, StopSequences) {
   EXPECT_EQ(sequence.num_generated_tokens(), 6);
   EXPECT_EQ(sequence.num_tokens(), 9);
   std::vector<int32_t> desired_tokens = {1, 2, 4, 3, 4, 3, 5, 6, 7};
-  EXPECT_EQ(sequence.token_ids().to_vector(), desired_tokens);
+  EXPECT_EQ(sequence.token_ids(), desired_tokens);
 }
 
 TEST(SequenceTest, DiscardTokenIds) {
@@ -195,7 +195,7 @@ TEST(SequenceTest, DiscardTokenIds) {
   EXPECT_EQ(sequence.num_prompt_tokens(), 3);
   EXPECT_EQ(sequence.num_generated_tokens(), 0);
   EXPECT_EQ(sequence.num_tokens(), 3);
-  EXPECT_EQ(sequence.token_ids().to_vector(), prompt_tokens);
+  EXPECT_EQ(sequence.token_ids(), prompt_tokens);
 
   sequence.append_blocks(allocator.allocate(10));
   sequence.commit_kv_cache(prompt_tokens.size());
@@ -209,7 +209,7 @@ TEST(SequenceTest, DiscardTokenIds) {
   EXPECT_EQ(sequence.num_tokens(), 5);
 
   std::vector<int32_t> desired_tokens = {1, 2, 4, 40, 50};
-  EXPECT_EQ(sequence.token_ids().to_vector(), desired_tokens);
+  EXPECT_EQ(sequence.token_ids(), desired_tokens);
 }
 
 }  // namespace llm


### PR DESCRIPTION
this diff also added optimization for prefix cache: split node for partial match in match function.