### PR TITLE
[fix] use gcc11 for cuda 11.8

### DIFF
--- a/.github/workflows/publish_base_image.yml
+++ b/.github/workflows/publish_base_image.yml
@@ -30,6 +30,9 @@ jobs:
           build-args: |
             UBUNTU_VERSION=22.04
             CUDA_VERSION=12.1
+            GCC_VERSION=12
+            CMAKE_VERSION=3.18.5
+            NINJA_VERSION=1.9.0
           tags: |
             vectorchai/scalellm_builder:cuda12.1-ubuntu22.04
             vectorchai/scalellm_builder:cuda12.1
@@ -43,6 +46,9 @@ jobs:
           build-args: |
             UBUNTU_VERSION=22.04
             CUDA_VERSION=11.8
+            GCC_VERSION=11
+            CMAKE_VERSION=3.18.5
+            NINJA_VERSION=1.9.0
           tags: |
             vectorchai/scalellm_builder:cuda11.8-ubuntu22.04
             vectorchai/scalellm_builder:cuda11.8


### PR DESCRIPTION
fix the build error for cuda 11.8

/usr/local/cuda/bin/../targets/x86_64-linux/include/crt/host_config.h:132:2: error: #error -- unsupported GNU version! gcc versions later than 11 are not supported! The nvcc flag '-allow-unsupported-compiler' can be used to override this version check; however, using an unsupported host compiler may cause compilation failure or incorrect run time execution. Use at your own risk.
        132 | #error -- unsupported GNU version! gcc versions later than 11 are not supported! The nvcc flag '-allow-unsupported-compiler' can be used to override this version check; however, using an unsupported host compiler may cause compilation failure or incorrect run time execution. Use at your own risk.