### PR TITLE
feat: added token related latency metrics

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -6,4 +6,4 @@ scrape_configs:
   - job_name: scalellm
     static_configs:
       - targets:
-          - 'host.docker.internal:8000'
+          - 'host.docker.internal:8080'

--- a/src/engine/batch_test.cpp
+++ b/src/engine/batch_test.cpp
@@ -1,5 +1,6 @@
 #include "batch.h"
 
+#include <absl/time/clock.h>
 #include <gtest/gtest.h>
 
 #include <cstdint>
@@ -43,6 +44,7 @@ TEST(BatchTest, Basic) {
   // sequence in prefill phase
   Sequence seq1(/*prompt=*/"",
                 /*token_ids=*/{1, 3, 5, 7, 5, 4, 3, 2, 1},
+                absl::Now(),
                 capacity,
                 options);
   seq1.append_blocks(allocator.allocate(3));  // [1, 2, 3]
@@ -50,6 +52,7 @@ TEST(BatchTest, Basic) {
   // seq in decode phase
   Sequence seq2(/*prompt=*/"",
                 /*token_ids=*/{2, 4, 6, 8, 6, 4, 2},
+                absl::Now(),
                 capacity,
                 options);
   seq2.append_blocks(allocator.allocate(4));  // [4, 5, 6, 7]
@@ -60,6 +63,7 @@ TEST(BatchTest, Basic) {
   Sequence seq3(
       /*prompt=*/"",
       /*token_ids=*/{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19},
+      absl::Now(),
       capacity,
       options);
   seq3.append_blocks(allocator.allocate(5));  // [8, 9, 10, 11, 12]

--- a/src/request/request.cpp
+++ b/src/request/request.cpp
@@ -28,8 +28,11 @@ void Request::add_sequence() {
   options.sampling_param = this->sampling_param;
   options.stopping_criteria = this->stopping_criteria;
 
-  sequences.emplace_back(
-      this->prompt, this->prompt_tokens, this->seq_capacity, options);
+  sequences.emplace_back(this->prompt,
+                         this->prompt_tokens,
+                         this->created_time,
+                         this->seq_capacity,
+                         options);
 }
 
 bool Request::is_finished() const {

--- a/src/request/sequence.h
+++ b/src/request/sequence.h
@@ -52,6 +52,7 @@ class Sequence final {
 
   Sequence(const std::string_view& prompt,
            const std::vector<int32_t>& prompt_token_ids,
+           const absl::Time& created_time,
            size_t capacity,
            const Options& option);
 
@@ -157,6 +158,9 @@ class Sequence final {
   std::string decode_delta_text(const Slice<int32_t>& token_ids,
                                 const Tokenizer& tokenizer);
 
+  // whether the delta text is decoded
+  bool no_delta_text_decoded() const { return no_delta_text_decoded_; }
+
   // get the offset of output tokens
   size_t output_offset() const { return decoder_.output_offset(); }
 
@@ -192,17 +196,17 @@ class Sequence final {
   bool is_closed() const { return closed_; }
 
   // get the inter-token latency
-  double inter_token_latency() const { return inter_token_latency_; }
+  double inter_token_latency(const absl::Time& now);
 
  private:
   // global unique id for the sequence
   const int64_t id_;
 
-  // last time when a token is added to the sequence
-  absl::Time last_token_added_time_;
+  // last token generation time
+  absl::Time last_token_time_;
 
-  // the time between two tokens generated for the sequence, in seconds
-  double inter_token_latency_ = 0.0;
+  // whether the delta text is decoded
+  bool no_delta_text_decoded_ = true;
 
   // the index of the sequence in the request
   size_t index_ = 0;

--- a/src/request/sequence_test.cpp
+++ b/src/request/sequence_test.cpp
@@ -144,6 +144,7 @@ TEST(SequenceTest, DiscardTokenIds) {
   options.stopping_criteria.max_tokens = max_tokens;
   Sequence sequence(/*prompt=*/"",
                     prompt_tokens,
+                    absl::Now(),
                     /*capacity=*/200,
                     options);
   EXPECT_EQ(sequence.num_prompt_tokens(), 3);
@@ -182,6 +183,7 @@ TEST(SequenceTest, SpeculativeBasic) {
   options.stopping_criteria.max_tokens = 100;
   Sequence sequence(/*prompt=*/"",
                     prompt_tokens,
+                    absl::Now(),
                     /*capacity=*/200,
                     options);
 
@@ -211,6 +213,7 @@ TEST(SequenceTest, SpeculativeFullMatch) {
   options.stopping_criteria.max_tokens = 100;
   Sequence sequence(/*prompt=*/"",
                     prompt_tokens,
+                    absl::Now(),
                     /*capacity=*/200,
                     options);
 
@@ -254,6 +257,7 @@ TEST(SequenceTest, SpeculativeNoMatch) {
   options.stopping_criteria.max_tokens = 100;
   Sequence sequence(/*prompt=*/"",
                     prompt_tokens,
+                    absl::Now(),
                     /*capacity=*/200,
                     options);
 
@@ -297,6 +301,7 @@ TEST(SequenceTest, SpeculativePartiallyMatch) {
   options.stopping_criteria.max_tokens = 100;
   Sequence sequence(/*prompt=*/"",
                     prompt_tokens,
+                    absl::Now(),
                     /*capacity=*/200,
                     options);
 
@@ -339,6 +344,7 @@ TEST(SequenceTest, SpeculativeStopMaxTokens) {
   options.stopping_criteria.max_tokens = 2;
   Sequence sequence(/*prompt=*/"",
                     prompt_tokens,
+                    absl::Now(),
                     /*capacity=*/200,
                     options);
 
@@ -374,6 +380,7 @@ TEST(SequenceTest, SpeculativeStopEosTokenId) {
 
   Sequence sequence(/*prompt=*/"",
                     prompt_tokens,
+                    absl::Now(),
                     /*capacity=*/200,
                     options);
 

--- a/src/server/simple.cpp
+++ b/src/server/simple.cpp
@@ -184,7 +184,7 @@ int main(int argc, char* argv[]) {
     options.stopping_criteria = stopping_criteria;
     options.echo = true;
 
-    Sequence sequence(input, prompt_tokens, capacity, options);
+    Sequence sequence(input, prompt_tokens, absl::Now(), capacity, options);
 
     // allocate all slots for the sequence
     CHECK(block_manager->allocate_blocks_for(&sequence, capacity));


### PR DESCRIPTION
new added/updated metrics
```
$ curl localhost:8080/metrics
...
# HELP num_processing_tokens_total Total number of processing tokens
# TYPE num_processing_tokens_total counter
num_processing_tokens_total{type="generated"} 30
num_processing_tokens_total{type="prompt"} 22

# HELP prefix_cache_latency_seconds Latency of prefix cache in seconds
# TYPE prefix_cache_latency_seconds counter
prefix_cache_latency_seconds{op="evict"} 0
prefix_cache_latency_seconds{op="match"} 3.496e-06
prefix_cache_latency_seconds{op="insert"} 2.906e-06

# HELP prefix_cache_match_length_total Length of matched prefix in tokens
# TYPE prefix_cache_match_length_total counter
prefix_cache_match_length_total 0

# HELP allocate_blocks_latency_seconds Latency of blocks allocation in seconds
# TYPE allocate_blocks_latency_seconds counter
allocate_blocks_latency_seconds 1.059199999999999e-05

# HELP time_to_first_token_latency_seconds Histogram of time to first token latency in seconds
# TYPE time_to_first_token_latency_seconds histogram
time_to_first_token_latency_seconds_count 2
time_to_first_token_latency_seconds_sum 0.113438361
time_to_first_token_latency_seconds_bucket{le="0.001"} 0
time_to_first_token_latency_seconds_bucket{le="0.002"} 0
time_to_first_token_latency_seconds_bucket{le="0.005"} 0
time_to_first_token_latency_seconds_bucket{le="0.01"} 0
time_to_first_token_latency_seconds_bucket{le="0.02"} 0
time_to_first_token_latency_seconds_bucket{le="0.05"} 1
time_to_first_token_latency_seconds_bucket{le="0.1"} 2
time_to_first_token_latency_seconds_bucket{le="0.5"} 2
time_to_first_token_latency_seconds_bucket{le="1"} 2
time_to_first_token_latency_seconds_bucket{le="+Inf"} 2

# HELP inter_token_latency_seconds Histogram of inter token latency in seconds
# TYPE inter_token_latency_seconds histogram
inter_token_latency_seconds_count 30
inter_token_latency_seconds_sum 0.300972625
inter_token_latency_seconds_bucket{le="0.001"} 0
inter_token_latency_seconds_bucket{le="0.002"} 0
inter_token_latency_seconds_bucket{le="0.005"} 0
inter_token_latency_seconds_bucket{le="0.01"} 9
inter_token_latency_seconds_bucket{le="0.02"} 30
inter_token_latency_seconds_bucket{le="0.05"} 30
inter_token_latency_seconds_bucket{le="0.1"} 30
inter_token_latency_seconds_bucket{le="0.5"} 30
inter_token_latency_seconds_bucket{le="1"} 30
inter_token_latency_seconds_bucket{le="+Inf"} 30
```