### PR TITLE
kernel: upgrade cutlass to 3.5.0 + cuda 12.4 for sm89 fp8 support

### DIFF
--- a/cmake/cc_library.cmake
+++ b/cmake/cc_library.cmake
@@ -76,8 +76,9 @@ function(cc_library)
     # Generating header only library
     add_library(${CC_LIB_NAME} INTERFACE)
     target_include_directories(${CC_LIB_NAME}
-      INTERFACE "$<BUILD_INTERFACE:${COMMON_INCLUDE_DIRS}>"
-      PUBLIC ${CC_LIB_INCLUDES}
+      INTERFACE 
+        "$<BUILD_INTERFACE:${COMMON_INCLUDE_DIRS}>"
+        ${CC_LIB_INCLUDES}
     )
 
     target_link_libraries(${CC_LIB_NAME}

--- a/cmake/cc_test.cmake
+++ b/cmake/cc_test.cmake
@@ -41,7 +41,7 @@ function(cc_test)
     CC_TEST # prefix
     "" # options
     "NAME" # one value args
-    "SRCS;COPTS;LINKOPTS;DEPS;ARGS;DATA" # multi value args
+    "SRCS;COPTS;LINKOPTS;DEPS;INCLUDES;ARGS;DATA" # multi value args
     ${ARGN}
   )
 
@@ -55,7 +55,9 @@ function(cc_test)
   add_executable(${CC_TEST_NAME})
   target_sources(${CC_TEST_NAME} PRIVATE ${CC_TEST_SRCS})
   target_include_directories(${CC_TEST_NAME}
-    PUBLIC "$<BUILD_INTERFACE:${COMMON_INCLUDE_DIRS}>"
+    PUBLIC 
+      "$<BUILD_INTERFACE:${COMMON_INCLUDE_DIRS}>" 
+      ${CC_TEST_INCLUDES}
   )
 
   target_compile_options(${CC_TEST_NAME}

--- a/src/kernels/CMakeLists.txt
+++ b/src/kernels/CMakeLists.txt
@@ -73,5 +73,5 @@ cc_library(
 )
 
 add_subdirectory(flash_attn)
-# add_subdirectory(flash_infer)
+add_subdirectory(attention)
 

--- a/src/kernels/attention/CMakeLists.txt
+++ b/src/kernels/attention/CMakeLists.txt
@@ -1,0 +1,23 @@
+include(cc_library)
+include(cc_test)
+
+cc_library(
+  NAME 
+    attention.kernels
+  SRCS 
+    # attention.cu
+  INCLUDES
+    include
+)
+
+cc_test(
+  NAME
+    cute_test
+  SRCS
+    cute_test.cpp
+  INCLUDES
+    include
+  DEPS
+    GTest::gtest_main
+    torch # include torch for CUDA configuration for now
+)

--- a/src/kernels/attention/cute_test.cpp
+++ b/src/kernels/attention/cute_test.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+#include <cute/tensor.hpp>
+
+namespace llm {
+
+TEST(CuteTest, Layout) { EXPECT_TRUE(true); }
+
+}  // namespace llm

--- a/src/kernels/attention/include
+++ b/src/kernels/attention/include
@@ -1,0 +1,1 @@
+../../../third_party/cutlass/include

--- a/src/kernels/flash_attn/src/flash_fwd_kernel.h
+++ b/src/kernels/flash_attn/src/flash_fwd_kernel.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <cute/algorithm/copy.hpp>
+#include <cute/tensor.hpp>
 
 #include <cutlass/cutlass.h>
 #include <cutlass/array.h>

--- a/src/kernels/flash_attn/src/flash_fwd_kernel.h
+++ b/src/kernels/flash_attn/src/flash_fwd_kernel.h
@@ -4,18 +4,18 @@
 
 #pragma once
 
-#include <cute/tensor.hpp>
-
-#include <cutlass/cutlass.h>
 #include <cutlass/array.h>
+#include <cutlass/cutlass.h>
 #include <cutlass/numeric_types.h>
+
+#include <cute/tensor.hpp>
 
 #include "block_info.h"
 #include "kernel_traits.h"
-#include "utils.h"
-#include "softmax.h"
 #include "mask.h"
 #include "rotary.h"
+#include "softmax.h"
+#include "utils.h"
 
 namespace flash {
 

--- a/src/kernels/flash_attn/src/mask.h
+++ b/src/kernels/flash_attn/src/mask.h
@@ -6,6 +6,8 @@
 
 #include <cute/tensor.hpp>
 
+#include "utils.h"
+
 namespace flash {
 
 using namespace cute;

--- a/src/kernels/flash_attn/src/rotary.h
+++ b/src/kernels/flash_attn/src/rotary.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <cute/algorithm/copy.hpp>
+#include <cute/tensor.hpp>
 
 #include "utils.h"
 

--- a/src/kernels/flash_attn/src/utils.h
+++ b/src/kernels/flash_attn/src/utils.h
@@ -14,8 +14,7 @@
 #include <cuda_bf16.h>
 #endif
 
-#include <cute/algorithm/copy.hpp>
-#include <cute/algorithm/gemm.hpp>
+#include <cute/tensor.hpp>
 
 #include <cutlass/array.h>
 #include <cutlass/cutlass.h>

--- a/src/kernels/flash_attn/src/utils.h
+++ b/src/kernels/flash_attn/src/utils.h
@@ -14,12 +14,12 @@
 #include <cuda_bf16.h>
 #endif
 
-#include <cute/tensor.hpp>
-
 #include <cutlass/array.h>
 #include <cutlass/cutlass.h>
 #include <cutlass/numeric_conversion.h>
 #include <cutlass/numeric_types.h>
+
+#include <cute/tensor.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
- [ ] support fp8 kv cache (sm89 + sm90)
* paged kv cache
* various length
* various page size
- [ ] support fp8 gemm (sm89 + sm90)
- [ ] support sm90 (TMA + WGMMA)
- [ ] support sm75
