### PR TITLE
ci: disable pip cache to avoid hash mismatch error

### DIFF
--- a/.github/workflows/package_test.yml
+++ b/.github/workflows/package_test.yml
@@ -103,7 +103,7 @@ jobs:
         conda activate ${ENV_NAME}
 
         # Install PyTorch
-        pip install torch==${TORCH_VERSION} -i "https://download.pytorch.org/whl/cu${CUDA_VERSION//./}"
+        pip install --no-cache-dir torch==${TORCH_VERSION} -i "https://download.pytorch.org/whl/cu${CUDA_VERSION//./}"
 
         # Uninstall previous version of the package and install the new one
         pip uninstall -y scalellm

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -73,7 +73,7 @@ jobs:
         conda activate ${ENV_NAME}
 
         # Install PyTorch
-        pip install torch==${TORCH_VERSION} -i "https://download.pytorch.org/whl/cu${CUDA_VERSION//./}"
+        pip install --no-cache-dir torch==${TORCH_VERSION} -i "https://download.pytorch.org/whl/cu${CUDA_VERSION//./}"
 
         # Uninstall previous version of the package and install the new one
         pip uninstall -y scalellm

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -24,7 +24,7 @@ PYVER="${PYTHON_VERSION//./}"
 export PATH="/opt/python/cp${PYVER}-cp${PYVER}/bin:$PATH"
 
 # install PyTorch
-pip install torch==$TORCH_VERSION -i "https://download.pytorch.org/whl/cu${CUDA_VERSION//./}"
+pip install --no-cache-dir torch==$TORCH_VERSION -i "https://download.pytorch.org/whl/cu${CUDA_VERSION//./}"
 
 # install other dependencies
 pip install numpy jinja2


### PR DESCRIPTION
ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise, examine the package contents carefully; someone may have tampered with them.
    nvidia-cusparse-cu12==12.1.0.106 from https://download.pytorch.org/whl/cu121/nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl#sha256=f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c (from torch==2.4.0):
        Expected sha256 f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c
             Got        911befe2250b2c01281278eed38a04766c4ba0fec12dd3d0457d3f027e6e2b01
