### PR TITLE
cmake: make includes private and disable jinja2cpp build

### DIFF
--- a/cmake/cc_library.cmake
+++ b/cmake/cc_library.cmake
@@ -68,6 +68,7 @@ function(cc_library)
     target_include_directories(${CC_LIB_NAME}
       PUBLIC 
         "$<BUILD_INTERFACE:${COMMON_INCLUDE_DIRS}>"
+      PRIVATE
         ${CC_LIB_INCLUDES}
     )
     target_compile_options(${CC_LIB_NAME} PRIVATE ${CC_LIB_COPTS})

--- a/cmake/cc_test.cmake
+++ b/cmake/cc_test.cmake
@@ -57,6 +57,7 @@ function(cc_test)
   target_include_directories(${CC_TEST_NAME}
     PUBLIC 
       "$<BUILD_INTERFACE:${COMMON_INCLUDE_DIRS}>" 
+    PRIVATE
       ${CC_TEST_INCLUDES}
   )
 

--- a/src/chat_template/CMakeLists.txt
+++ b/src/chat_template/CMakeLists.txt
@@ -15,27 +15,27 @@ cc_library (
     glog::glog
 )
 
-cc_library (
-  NAME
-    jinja_chat_template
-  HDRS
-    jinja_chat_template.h
-  SRCS
-    jinja_chat_template.cpp
-  DEPS
-    :jinja2cpp
-    nlohmann_json::nlohmann_json
-    glog::glog
-)
+# cc_library (
+#   NAME
+#     jinja_chat_template
+#   HDRS
+#     jinja_chat_template.h
+#   SRCS
+#     jinja_chat_template.cpp
+#   DEPS
+#     :jinja2cpp
+#     nlohmann_json::nlohmann_json
+#     glog::glog
+# )
 
-cc_test (
-  NAME
-    chat_template_test
-  SRCS
-    jinja_chat_template_test.cpp
-  DEPS
-    :chat_template
-    :jinja_chat_template
-    GTest::gtest_main
-)
+# cc_test (
+#   NAME
+#     chat_template_test
+#   SRCS
+#     jinja_chat_template_test.cpp
+#   DEPS
+#     :chat_template
+#     :jinja_chat_template
+#     GTest::gtest_main
+# )
 

--- a/src/kernels/quantization/marlin/CMakeLists.txt
+++ b/src/kernels/quantization/marlin/CMakeLists.txt
@@ -29,7 +29,8 @@ cc_library(
     awq_repack.cu
     # sparse.cu
   INCLUDES
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
   DEPS
     torch
 )

--- a/src/kernels/quantization/marlin/CMakeLists.txt
+++ b/src/kernels/quantization/marlin/CMakeLists.txt
@@ -30,7 +30,6 @@ cc_library(
     # sparse.cu
   INCLUDES
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}
   DEPS
     torch
 )

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -17,6 +17,6 @@ cc_library(
 )
 
 add_subdirectory(sentencepiece)
-add_subdirectory(jinja2cpp)
 add_subdirectory(nvbench)
+# add_subdirectory(jinja2cpp)
 


### PR DESCRIPTION
This diff would fix following build error:
```
/home/michael/code/ScaleLLM/src/kernels/quantization/marlin/./memory.h:17:41: error: there are no arguments to ‘__cvta_generic_to_shared’ that depend on a template parameter, so a declaration of ‘__cvta_generic_to_shared’ must be available [-fpermissive]
[build]    17 |   uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
[build]       |                                         ^~~~~~~~~~~~~~~~~~~~~~~~
[build] /home/michael/code/ScaleLLM/src/kernels/quantization/marlin/./memory.h:17:41: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
[build] /home/michael/code/ScaleLLM/src/kernels/quantization/marlin/./memory.h: In function ‘void marlin::cp_async4_pred(void*, const void*, bool)’:
[build] /home/michael/code/ScaleLLM/src/kernels/quantization/marlin/./memory.h:50:41: error: ‘__cvta_generic_to_shared’ was not declared in this scope
[build]    50 |   uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
[build]       |                                         ^~~~~~~~~~~~~~~~~~~~~~~~
```