### PR TITLE
fix: put item into asyncio.Queue in a thread-safe way

### DIFF
--- a/examples/async_stream_chat.py
+++ b/examples/async_stream_chat.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from scalellm import AsyncLLMEngine, Message, SamplingParams
 
 

--- a/examples/async_stream_complete.py
+++ b/examples/async_stream_complete.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from scalellm import AsyncLLMEngine, SamplingParams
 
 

--- a/examples/stream_chat.py
+++ b/examples/stream_chat.py
@@ -1,8 +1,7 @@
-import asyncio
 from scalellm import AsyncLLMEngine, Message, SamplingParams
 
 
-async def main():
+def main():
     # Create an LLM engine.
     with AsyncLLMEngine(
         model="meta-llama/Meta-Llama-3.1-8B-Instruct", devices="cuda"
@@ -27,14 +26,14 @@ async def main():
             messages.append(Message(role="user", content=prompt))
 
             try:
-                output_stream = await engine.schedule_chat_async(
+                output_stream = engine.schedule_chat(
                     messages=messages,
                     sampling_params=sampling_params,
                     stream=True,
                 )
                 assistant_response = ""
                 print("\n[Assistant]: ", end="", flush=True)
-                async for output in output_stream:
+                for output in output_stream:
                     if len(output.outputs) > 0:
                         response = output.outputs[0].text
                         assistant_response += response
@@ -50,4 +49,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/examples/stream_complete.py
+++ b/examples/stream_complete.py
@@ -1,8 +1,7 @@
-import asyncio
 from scalellm import AsyncLLMEngine, SamplingParams
 
 
-async def main():
+def main():
     # Create an LLM engine.
     with AsyncLLMEngine(model="meta-llama/Meta-Llama-3.1-8B", devices="cuda") as engine:
         sampling_params = SamplingParams(
@@ -17,12 +16,12 @@ async def main():
             if prompt == "exit":
                 break
             try:
-                output_stream = await engine.schedule_async(
+                output_stream = engine.schedule(
                     prompt=prompt,
                     sampling_params=sampling_params,
                     stream=True,
                 )
-                async for output in output_stream:
+                for output in output_stream:
                     if len(output.outputs) > 0:
                         print(output.outputs[0].text, end="", flush=True)
                 print()
@@ -33,4 +32,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/scalellm/llm_engine.py
+++ b/scalellm/llm_engine.py
@@ -3,7 +3,8 @@ import os
 import queue
 from typing import List, Optional
 
-from scalellm._C import LLMHandler, Message, Priority, RequestOutput, SamplingParams
+from scalellm._C import (LLMHandler, Message, Priority, RequestOutput,
+                         SamplingParams)
 from scalellm.downloader import download_hf_model
 from scalellm.errors import ValidationError
 


### PR DESCRIPTION
`asyncio.Queue` is not thread-safe, so we need to use `loop.call_soon_threadsafe` to schedule callbacks from other threads. This diff fix the potential contention issue.

Thanks @tp-nan for reporting the issue https://github.com/vectorch-ai/ScaleLLM/issues/323.