### PR TITLE
ci: fix package test workflow

### DIFF
--- a/.github/workflows/publish_devel_image.yml
+++ b/.github/workflows/publish_devel_image.yml
@@ -21,7 +21,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda: ["11.8", "12.1", "12.4", "12.6"]
+        cuda: ["12.1", "12.4", "12.6"]
+        gcc: ["12"]
+        include: # build cuda 11.8 with gcc 11
+          - cuda: "11.8"
+            gcc: "11"
     runs-on: [self-hosted, linux, build]
     steps:
       - name: Checkout repository
@@ -53,7 +57,7 @@ jobs:
           build-args: |
             UBUNTU_VERSION=22.04
             CUDA_VERSION=${{ matrix.cuda }}
-            GCC_VERSION=12
+            GCC_VERSION=${{ matrix.gcc }}
           tags: |
             vectorchai/scalellm_devel:cuda${{ matrix.cuda }}-ubuntu22.04
             vectorchai/scalellm_devel:cuda${{ matrix.cuda }}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,4 +9,4 @@ openai==1.37.0
 six==1.16.0
 transformers==4.43.3
 accelerate==0.33.0
-httpx==0.27.2 # https://community.openai.com/t/typeerror-asyncclient-init-got-an-unexpected-keyword-argument-proxies/1040287
+httpx==0.27.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,4 @@ openai==1.37.0
 six==1.16.0
 transformers==4.43.3
 accelerate==0.33.0
+httpx==0.27.2 # https://community.openai.com/t/typeerror-asyncclient-init-got-an-unexpected-keyword-argument-proxies/1040287


### PR DESCRIPTION
* added `httpx==0.27.2` into requirements.txt to fix `TypeError: AsyncClient.__init__() got an unexpected keyword argument ‘proxies’`

https://community.openai.com/t/typeerror-asyncclient-init-got-an-unexpected-keyword-argument-proxies/1040287/5

* build cuda 11.8 devel image with gcc 11