### PR TITLE
kernel: revert mla ping-pong rmem change

### DIFF
--- a/src/kernels/attention/cute_extensions.cuh
+++ b/src/kernels/attention/cute_extensions.cuh
@@ -19,43 +19,7 @@ constexpr bool
                   cute::void_t<decltype(declval<typename Copy_Atom::Traits>()
                                             .with(declval<bool>()))>> = true;
 
-template <typename Layout, typename Shape>
-CUTE_HOST_DEVICE constexpr auto with_shape(Layout l, Shape s) {
-  if constexpr (is_underscore<Shape>::value) {
-    return l;
-  } else {
-    return l.with_shape(s);
-  }
-}
-
 }  // namespace detail
-
-// returns a fragment with the a shape (MMA, mma_m, mma_k)
-template <typename ThrMMA, class ATensor, typename ShapeM, typename ShapeK>
-CUTE_HOST_DEVICE constexpr auto partition_fragment_A(const ThrMMA& thr_mma,
-                                                     ATensor&& atensor,
-                                                     const ShapeM& mma_m,
-                                                     const ShapeK& mma_k) {
-  auto a = thr_mma.partition_A(atensor);
-  auto l = get_nonswizzle_portion(a.layout());
-  auto a_l = make_layout(get<0>(l),
-                         detail::with_shape(get<1>(l), mma_m),
-                         detail::with_shape(get<2>(l), mma_k));
-  return thr_mma.make_fragment_A(a_l);
-}
-
-template <typename ThrMMA, class BTensor, typename ShapeN, typename ShapeK>
-CUTE_HOST_DEVICE constexpr auto partition_fragment_B(const ThrMMA& thr_mma,
-                                                     BTensor&& btensor,
-                                                     const ShapeN& mma_n,
-                                                     const ShapeK& mma_k) {
-  auto b = thr_mma.partition_B(btensor);
-  auto l = get_nonswizzle_portion(b.layout());
-  auto b_l = make_layout(get<0>(l),
-                         detail::with_shape(get<1>(l), mma_n),
-                         detail::with_shape(get<2>(l), mma_k));
-  return thr_mma.make_fragment_B(b_l);
-}
 
 template <int... Is, int B, int M, int S, class Offset, class LayoutB>
 CUTE_HOST_DEVICE constexpr auto permute(

--- a/src/kernels/attention/mla_kernel_sm80.cuh
+++ b/src/kernels/attention/mla_kernel_sm80.cuh
@@ -208,27 +208,22 @@ __global__ __launch_bounds__(Traits::kThreadNum) void mla_kernel_sm80(
   auto thr_mma_qk = tiled_mma_qk.get_slice(tidx);
   // GEMM-I: S = Q@K.T
   // sQ/sK: (BLK_M, BLK_K, STAGES)
-  auto tSrQ = partition_fragment_A(
-      thr_mma_qk, sQ(_, _, _0{}), _, _2{});  // (MMA, MMA_M, _2)
-  auto tSrK = partition_fragment_B(
-      thr_mma_qk, sK(_, _, _0{}), _, _2{});  // (MMA, MMA_N, _2)
-
-  auto tSrQ_rope =
-      partition_fragment_A(thr_mma_qk, sQ_rope, _, _2{});  // (MMA, MMA_M, _2)
-  auto tSrK_rope =
-      partition_fragment_B(thr_mma_qk, sK_rope, _, _2{});  // (MMA, MMA_N, _2)
+  auto tSrQ = thr_mma_qk.partition_fragment_A(sQ(_, _, _0{}));
+  auto tSrK = thr_mma_qk.partition_fragment_B(sK(_, _, _0{}));
+  auto tSrQ_rope = thr_mma_qk.partition_fragment_A(sQ_rope);
+  auto tSrK_rope = thr_mma_qk.partition_fragment_B(sK_rope);
 
   // s2r tiled copy for q
   SmemTiledCopyQ smem_tiled_copy_Q;
   auto smem_thr_copy_Q = smem_tiled_copy_Q.get_slice(tidx);
   // (CPY, CPY_M, CPY_K, STAGES)
   auto tCsQ = smem_thr_copy_Q.partition_S(sQ);
-  // (CPY, CPY_M, _2)
+  // (CPY, CPY_M, CPY_K)
   auto tCrQ = smem_thr_copy_Q.retile_D(tSrQ);
 
   // (CPY, CPY_M, CPY_K)
   auto tCsQ_rope = smem_thr_copy_Q.partition_S(sQ_rope);
-  // (CPY, CPY_M, _2)
+  // (CPY, CPY_M, CPY_K)
   auto tCrQ_rope = smem_thr_copy_Q.retile_D(tSrQ_rope);
 
   // s2r tiled copy for k
@@ -236,12 +231,12 @@ __global__ __launch_bounds__(Traits::kThreadNum) void mla_kernel_sm80(
   auto smem_thr_copy_K = smem_tiled_copy_K.get_slice(tidx);
   // (CPY, CPY_N, CPY_K, STAGES)
   auto tCsK = smem_thr_copy_K.partition_S(sK);
-  // (CPY, CPY_N, _2)
+  // (CPY, CPY_N, CPY_K)
   auto tCrK = smem_thr_copy_K.retile_D(tSrK);
 
   // (CPY, CPY_N, CPY_K)
   auto tCsK_rope = smem_thr_copy_K.partition_S(sK_rope);
-  // (CPY, CPY_N, _2)
+  // (CPY, CPY_N, CPY_K)
   auto tCrK_rope = smem_thr_copy_K.retile_D(tSrK_rope);
 
   // S = Q@K.T
@@ -259,17 +254,14 @@ __global__ __launch_bounds__(Traits::kThreadNum) void mla_kernel_sm80(
       // prefetch next kv
       if (k != size<2>(tCsQ_s) - 1) {
         const auto next_k = k + 1;
-        cute::copy(
-            smem_tiled_copy_Q, tCsQ_s(_, _, next_k), tCrQ(_, _, (next_k & 1)));
-        cute::copy(
-            smem_tiled_copy_K, tCsK_s(_, _, next_k), tCrK(_, _, (next_k & 1)));
+        cute::copy(smem_tiled_copy_Q, tCsQ_s(_, _, next_k), tCrQ(_, _, next_k));
+        cute::copy(smem_tiled_copy_K, tCsK_s(_, _, next_k), tCrK(_, _, next_k));
       }
-      cute::gemm(tiled_mma_qk, tSrQ(_, _, (k & 1)), tSrK(_, _, (k & 1)), tSrS);
+      cute::gemm(tiled_mma_qk, tSrQ(_, _, k), tSrK(_, _, k), tSrS);
     }
   };
 
   auto compute_qk_rope = [&](auto& tSrS) {
-    // tCsQ_rope: (CPY, CPY_M, CPY_K) => tCrQ_rope: (CPY, CPY_M, _2)
     cute::copy(smem_tiled_copy_Q, tCsQ_rope(_, _, _0{}), tCrQ_rope(_, _, _0{}));
     cute::copy(smem_tiled_copy_K, tCsK_rope(_, _, _0{}), tCrK_rope(_, _, _0{}));
 
@@ -279,15 +271,12 @@ __global__ __launch_bounds__(Traits::kThreadNum) void mla_kernel_sm80(
         const auto next_k = k + 1;
         cute::copy(smem_tiled_copy_Q,
                    tCsQ_rope(_, _, next_k),
-                   tCrQ_rope(_, _, (next_k & 1)));
+                   tCrQ_rope(_, _, next_k));
         cute::copy(smem_tiled_copy_K,
                    tCsK_rope(_, _, next_k),
-                   tCrK_rope(_, _, (next_k & 1)));
+                   tCrK_rope(_, _, next_k));
       }
-      cute::gemm(tiled_mma_qk,
-                 tSrQ_rope(_, _, (k & 1)),
-                 tSrK_rope(_, _, (k & 1)),
-                 tSrS);
+      cute::gemm(tiled_mma_qk, tSrQ_rope(_, _, k), tSrK_rope(_, _, k), tSrS);
     }
   };
 
@@ -295,18 +284,18 @@ __global__ __launch_bounds__(Traits::kThreadNum) void mla_kernel_sm80(
   TiledMma_PV tiled_mma_pv;
   auto thr_mma_pv = tiled_mma_pv.get_slice(tidx);
   // sS: (BLK_M, BLK_N)
-  // (MMA, MMA_M, _2)
-  auto tOrP = partition_fragment_A(thr_mma_pv, sP, _, _2{});
+  // (MMA, MMA_M, MMA_K)
+  auto tOrP = thr_mma_pv.partition_fragment_A(sP);
   // sVt: (BLK_K, BLK_N, STAGES)
-  // (MMA, MMA_N, _2)
-  auto tOrVt = partition_fragment_B(thr_mma_pv, sVt(_, _, _0{}), _, _2{});
+  // (MMA, MMA_N, MMA_K)
+  auto tOrVt = thr_mma_pv.partition_fragment_B(sVt(_, _, _0{}));
 
   // s2r tiled copy for p
   SmemTiledCopyP smem_tiled_copy_P;
   auto smem_thr_copy_P = smem_tiled_copy_P.get_slice(tidx);
   // (CPY, CPY_M, CPY_K)
   auto tCsP = smem_thr_copy_P.partition_S(sP);
-  // (CPY, CPY_M, _2)
+  // (CPY, CPY_M, CPY_K)
   auto tCrP = smem_thr_copy_P.retile_D(tOrP);
 
   // s2r tiled copy for vt
@@ -314,7 +303,7 @@ __global__ __launch_bounds__(Traits::kThreadNum) void mla_kernel_sm80(
   auto smem_thr_copy_Vt = smem_tiled_copy_Vt.get_slice(tidx);
   // (CPY, CPY_N, CPY_K, STAGES)
   auto tCsVt = smem_thr_copy_Vt.partition_S(sVt);
-  // (CPY, CPY_N, _2)
+  // (CPY, CPY_N, CPY_K)
   auto tCrVt = smem_thr_copy_Vt.retile_D(tOrVt);
 
   // O = P*V = softmax(S)*V
@@ -325,7 +314,6 @@ __global__ __launch_bounds__(Traits::kThreadNum) void mla_kernel_sm80(
 
     // (CPY, CPY_N, CPY_K, STAGES)
     auto tCsVt_s = tCsVt(_, _, _, s);
-    // tCsVt_s: (CPY, CPY_N, CPY_K) => tCrVt: (CPY, CPY_N, _2)
     cute::copy(smem_tiled_copy_P, tCsP(_, _, _0{}), tCrP(_, _, _0{}));
     cute::copy(smem_tiled_copy_Vt, tCsVt_s(_, _, _0{}), tCrVt(_, _, _0{}));
 
@@ -333,14 +321,11 @@ __global__ __launch_bounds__(Traits::kThreadNum) void mla_kernel_sm80(
     for (int k = 0; k < size<2>(tCsVt_s); ++k) {
       if (k != size<2>(tCsVt_s) - 1) {
         const auto next_k = k + 1;
+        cute::copy(smem_tiled_copy_P, tCsP(_, _, next_k), tCrP(_, _, next_k));
         cute::copy(
-            smem_tiled_copy_P, tCsP(_, _, next_k), tCrP(_, _, (next_k & 1)));
-        cute::copy(smem_tiled_copy_Vt,
-                   tCsVt_s(_, _, next_k),
-                   tCrVt(_, _, (next_k & 1)));
+            smem_tiled_copy_Vt, tCsVt_s(_, _, next_k), tCrVt(_, _, next_k));
       }
-      cute::gemm(
-          tiled_mma_pv, tCrP(_, _, (k & 1)), tOrVt(_, _, (k & 1)), tOrO_s);
+      cute::gemm(tiled_mma_pv, tCrP(_, _, k), tOrVt(_, _, k), tOrO_s);
     }
   };
 


### PR DESCRIPTION
Reverts the MLA ping-pong rmem fine-grained tiling [change](https://github.com/vectorch-ai/ScaleLLM/pull/400), as it either improves performance or reduces register usage while generating the exact same SASS.