### PR TITLE
ci: use old version of setuptools to avoid Metadata-Version issue

### DIFF
--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -30,8 +30,9 @@ python -m pip install --upgrade pip
 pip install torch==$TORCH_VERSION -i "https://download.pytorch.org/whl/cu${CUDA_VERSION//./}"
 
 # install other dependencies
-pip install numpy jinja2
-pip install --upgrade setuptools wheel
+pip install numpy jinja2 wheel
+# use setuptools 76.1.0 to avoid issues with Metadata-Version
+pip install setuptools==76.1.0
 
 # set max cache size to 25GiB
 command -v ccache >/dev/null && ccache -M 25Gi


### PR DESCRIPTION
fix issue: https://github.com/vectorch-ai/ScaleLLM/actions/runs/15263256144/job/42927830955

```
InvalidDistribution: Metadata is missing required fields: Name,        
         Version.                                                               
         Make sure the distribution includes the files where those fields are   
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,   
         2.0, 2.1, 2.2, 2.3.
```