### PR TITLE
feat: [1/n] added sm120 fmha using collective async copy

### DIFF
--- a/src/kernels/attention/CMakeLists.txt
+++ b/src/kernels/attention/CMakeLists.txt
@@ -57,10 +57,10 @@ cc_test(
   NAME
     mha_kernel_test
   SRCS
-    sm80_mha_test.cu
+    # sm80_mha_test.cu
     sm80_mha_pagedkv_test.cu
   DEPS
-    :attention.template
+    :attention.kernels
     absl::random_random
     :gtest_main
     torch
@@ -85,7 +85,7 @@ cc_test(
     sm80_mla_test.cu
     sm80_mla_pagedkv_test.cu
   DEPS
-    :attention.template
+    :attention.kernels
     absl::random_random
     :gtest_main
     torch

--- a/src/kernels/attention/CMakeLists.txt
+++ b/src/kernels/attention/CMakeLists.txt
@@ -57,9 +57,20 @@ cc_test(
   NAME
     mha_kernel_test
   SRCS
-    # mha_cpu_test.cpp
     sm80_mha_test.cu
     sm80_mha_pagedkv_test.cu
+  DEPS
+    :attention.template
+    absl::random_random
+    :gtest_main
+    torch
+)
+
+cc_test(
+  NAME
+    sm120_mha_kernel_test
+  SRCS
+    sm120_mha_test.cu
   DEPS
     :attention.template
     absl::random_random

--- a/src/kernels/attention/generate_instantiation_cu.py
+++ b/src/kernels/attention/generate_instantiation_cu.py
@@ -19,7 +19,7 @@ BOOL_MAP = {
 }
 
 
-MHA_KERNEL_TEMPLATE = """
+SM80_MHA_KERNEL_TEMPLATE = """
 #include "sm80_mha_launch.cuh"  // IWYU pragma: export
 #include "mha_params.h"         // IWYU pragma: export
 
@@ -28,6 +28,25 @@ namespace llm {{
 using Params = MHAPagedKVParams;
 
 template void sm80_launch_mha_kernel</*DTYPE=*/{DTYPE},
+                                     /*HEAD_DIM=*/{HEAD_DIM},
+                                     /*EVEN_K=*/{EVEN_K},
+                                     /*ALIBI=*/{ALIBI},
+                                     /*SOFT_CAP=*/{SOFT_CAP},
+                                     /*LOCAL=*/{LOCAL},
+                                     Params>(const Params& params,
+                                             cudaStream_t stream);
+}}  // namespace llm
+"""
+
+SM120_MHA_KERNEL_TEMPLATE = """
+#include "sm120_mha_launch.cuh"  // IWYU pragma: export
+#include "mha_params.h"          // IWYU pragma: export
+
+namespace llm {{
+
+using Params = MHAPagedKVParams;
+
+template void sm120_launch_mha_kernel</*DTYPE=*/{DTYPE},
                                      /*HEAD_DIM=*/{HEAD_DIM},
                                      /*EVEN_K=*/{EVEN_K},
                                      /*ALIBI=*/{ALIBI},
@@ -56,7 +75,7 @@ template void sm80_launch_mla_kernel</*DTYPE=*/{DTYPE},
 
 
 @dataclass
-class MHAKernel:
+class SM80MHAKernel:
     dtype: str
     head_dim: int
     even_k: bool
@@ -66,7 +85,7 @@ class MHAKernel:
 
     @property
     def template(self) -> str:
-        return MHA_KERNEL_TEMPLATE.format(
+        return SM80_MHA_KERNEL_TEMPLATE.format(
             DTYPE=DTYPE_MAP[self.dtype],
             HEAD_DIM=self.head_dim,
             EVEN_K=BOOL_MAP[self.even_k],
@@ -81,6 +100,33 @@ class MHAKernel:
             return "1" if val else "0"
 
         return f"sm80_mha_{self.dtype}_hd{self.head_dim}_ek{to_str(self.even_k)}_al{to_str(self.alibi)}_sc{to_str(self.soft_cap)}_lc{to_str(self.local)}.cu"
+
+@dataclass
+class SM120MHAKernel:
+    dtype: str
+    head_dim: int
+    even_k: bool
+    alibi: bool
+    soft_cap: bool
+    local: bool
+
+    @property
+    def template(self) -> str:
+        return SM120_MHA_KERNEL_TEMPLATE.format(
+            DTYPE=DTYPE_MAP[self.dtype],
+            HEAD_DIM=self.head_dim,
+            EVEN_K=BOOL_MAP[self.even_k],
+            ALIBI=BOOL_MAP[self.alibi],
+            SOFT_CAP=BOOL_MAP[self.soft_cap],
+            LOCAL=BOOL_MAP[self.local],
+        )
+
+    @property
+    def filename(self) -> str:
+        def to_str(val: bool) -> str:
+            return "1" if val else "0"
+
+        return f"sm120_mha_{self.dtype}_hd{self.head_dim}_ek{to_str(self.even_k)}_al{to_str(self.alibi)}_sc{to_str(self.soft_cap)}_lc{to_str(self.local)}.cu"
 
 
 @dataclass
@@ -102,7 +148,7 @@ class MLAKernel:
         return f"sm80_mla_{self.dtype}_hd{self.head_dim}_rhd{self.rope_head_dim}.cu"
 
 
-def gen_mha_kernels() -> Iterator[MHAKernel]:
+def gen_sm80_mha_kernels() -> Iterator[SM80MHAKernel]:
     # mha kernel instantiations
     for (
         dtype,
@@ -119,7 +165,33 @@ def gen_mha_kernels() -> Iterator[MHAKernel]:
         [False, True],  # soft_cap
         [False, True],  # local
     ):
-        yield MHAKernel(
+        yield SM80MHAKernel(
+            dtype=dtype,
+            head_dim=head_dim,
+            even_k=even_k,
+            alibi=alibi,
+            soft_cap=soft_cap,
+            local=local,
+        )
+
+def gen_sm120_mha_kernels() -> Iterator[SM120MHAKernel]:
+    # mha kernel instantiations
+    for (
+        dtype,
+        head_dim,
+        even_k,
+        alibi,
+        soft_cap,
+        local,
+    ) in itertools.product(
+        ["fp16"],  # dtype
+        [64],  # head_dim
+        [False, True],  # even_k
+        [False, True],  # alibi
+        [False, True],  # soft_cap
+        [False, True],  # local
+    ):
+        yield SM120MHAKernel(
             dtype=dtype,
             head_dim=head_dim,
             even_k=even_k,
@@ -150,7 +222,10 @@ if __name__ == "__main__":
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # written to several files to speed up compilation
-    for kernel in gen_mha_kernels():
+    for kernel in gen_sm80_mha_kernels():
+        (output_dir / kernel.filename).write_text(kernel.template)
+
+    for kernel in gen_sm120_mha_kernels():
         (output_dir / kernel.filename).write_text(kernel.template)
 
     for kernel in gen_mla_kernels():

--- a/src/kernels/attention/sm120_collective_epilogue.cuh
+++ b/src/kernels/attention/sm120_collective_epilogue.cuh
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <cute/container/array_aligned.hpp>
+#include <cute/layout.hpp>
+#include <cute/tensor.hpp>
+
+#include "fast_cast.cuh"
+#include "safe_copy.h"
+
+namespace llm {
+using namespace cute;
+
+template <class TileShape_, class Element_, int HeadDim_, bool EVEN_K_>
+struct Sm120CollectiveEpilogue {
+  using TileShape = TileShape_;
+  using Element = Element_;
+
+  static constexpr int kHeadDim = HeadDim_;
+  static constexpr bool EVEN_K = EVEN_K_;
+
+  static constexpr int kBlockM = get<0>(TileShape{});
+  static constexpr int kBlockK = get<2>(TileShape{});
+
+  using BLK_M = Int<kBlockM>;
+  using BLK_K = Int<kBlockK>;
+  using HEAD_DIM = Int<kHeadDim>;
+
+  using SmemLayoutAtom_ =
+      decltype(composition(Swizzle<3, 3, 3>{},
+                           Layout<Shape<_8, BLK_K>, Stride<BLK_K, _1>>{}));
+
+  // Q smem: (BLK_M, HEAD_DIM)
+  using SmemLayoutO =
+      decltype(tile_to_shape(SmemLayoutAtom_{}, Shape<BLK_M, HEAD_DIM>{}));
+
+  // use 128-bit vectorizing copy
+  using VectorizingCopy_ = AutoVectorizingCopyWithAssumedAlignment<128>;
+
+  // r2s copy atom for O
+  using SmemCopyAtom_ = Copy_Atom<VectorizingCopy_, Element>;
+
+  // Thr layout for gmem copy
+  using GmemCopyThrLayout_ =
+      std::conditional_t<kBlockK == 32,
+                         Layout<Shape<_32, _4>, Stride<_4, _1>>,
+                         Layout<Shape<_16, _8>, Stride<_8, _1>>>;
+
+  // s2g tiled copy for O
+  using GmemTiledCopyO = decltype(make_tiled_copy(
+      Copy_Atom<VectorizingCopy_, Element>{},
+      GmemCopyThrLayout_{},    // Thr layout: (_16,_8)/(_32, _4)
+      Layout<Shape<_1, _8>>{}  // Val layout: 8 vals per read
+      ));
+
+  struct SharedStorage : cute::aligned_struct<128> {
+    cute::array_aligned<Element, cute::cosize_v<SmemLayoutO>> smem_o;
+  };
+
+  // Host side kernel arguments
+  struct Arguments {};
+
+  // Device side kernel params
+  using Params = Arguments;
+
+  // Convert host side arguments to device side params
+  static Params to_underlying_arguments(Arguments const& args) { return args; }
+
+  template <class FrgTensor,
+            class TiledMma,
+            class TensorO,
+            class TensorCO,
+            class ResidueMNK>
+  CUTE_DEVICE void operator()(
+      const Params& /*params*/,
+      const FrgTensor& tOrAccO,  // (MMA, MMA_M, MMA_N)
+      TiledMma tiled_mma,
+      TensorO& gO,         // (BLK_M, HEAD_DIM)
+      const TensorCO& cO,  // (BLK_M, HEAD_DIM) => (M, K)
+      int tidx,
+      const ResidueMNK& residue_mnk,
+      char* smem) {
+    static constexpr int kBlockM = get<0>(TileShape{});
+
+    // Smem
+    auto& ss = *reinterpret_cast<SharedStorage*>(smem);
+    // (BLK_M, HEAD_DIM)
+    Tensor sO = make_tensor(make_smem_ptr(ss.smem_o.data()), SmemLayoutO{});
+
+    // 1. cast output from ElementAccumulator to Element
+    auto tOrO = make_tensor_like<Element>(tOrAccO);
+    fast_cast(tOrAccO, tOrO);
+
+    // 2. copy output from reg to smem
+    auto smem_tiled_copy_O = make_tiled_copy_C(SmemCopyAtom_{}, tiled_mma);
+    auto smem_thr_copy_O = smem_tiled_copy_O.get_thread_slice(tidx);
+    auto tSrO = smem_thr_copy_O.retile_S(tOrO);
+    auto tSsO = smem_thr_copy_O.partition_D(sO);
+    cute::copy(smem_tiled_copy_O, tSrO, tSsO);
+
+    // 3. copy output from smem to gmem
+    GmemTiledCopyO gmem_tiled_copy_O;
+    auto gmem_thr_copy_O = gmem_tiled_copy_O.get_thread_slice(tidx);
+
+    auto tOsO = gmem_thr_copy_O.partition_S(sO);  // (CPY,CPY_M,CPY_K)
+    auto tOgO = gmem_thr_copy_O.partition_D(gO);  // (CPY,CPY_M,CPY_K)
+    // (CPY,CPY_M,CPY_K) -> (blk_m, head_dim)
+    auto tOcO = gmem_thr_copy_O.partition_D(cO);
+
+    // wait for smem copy done before gmem copy
+    __syncthreads();
+
+    const auto residue_mk = select<0, 2>(residue_mnk);
+    safe_copy</*EVEN_M=*/false, EVEN_K, /*ZFILL_M=*/false, /*ZFILL_K=*/false>(
+        gmem_tiled_copy_O, tOsO, tOgO, tOcO, residue_mk);
+  }
+};
+}  // namespace llm

--- a/src/kernels/attention/sm120_collective_load_cpasync_ws.cuh
+++ b/src/kernels/attention/sm120_collective_load_cpasync_ws.cuh
@@ -9,7 +9,6 @@
 #include <cute/layout.hpp>
 #include <cute/tensor.hpp>
 
-#include "fast_math.h"
 #include "safe_copy.h"
 
 namespace llm {
@@ -91,12 +90,7 @@ struct Sm120CollectiveLoadCpAsyncWs {
   };
 
   // Host side arguments
-  struct Arguments {
-    // mask
-    int sliding_window = -1;
-
-    FastDivmod group_size;
-  };
+  struct Arguments {};
 
   // Device side params
   using Params = Arguments;
@@ -113,54 +107,31 @@ struct Sm120CollectiveLoadCpAsyncWs {
             class TensorK,
             class TensorV,
             class TensorCKV,
-            class BlockCoord,
             class ResidueMNK,
             class PipelineQ,
             class PipelineKV>
-  CUTE_DEVICE void load(const Params& params,
-                        const TensorQ& gQ,     // (BLK_M, HEAD_DIM)
-                        const TensorCQ& cQ,    // (BLK_M, HEAD_DIM) => (M, K)
-                        const TensorK& gK,     // (BLK_N, HEAD_DIM, n)
-                        const TensorV& gV,     // (BLK_N, HEAD_DIM, n)
-                        const TensorCKV& cKV,  // (BLK_N, HEAD_DIM, n) => (N, K)
-                        int tidx,
-                        const BlockCoord& blk_coord,
-                        const ResidueMNK& residue_mnk,  // (M, N, K)
-                        PipelineQ& q_pipeline,
-                        typename PipelineQ::PipelineState& q_state,
-                        PipelineKV& kv_pipeline,
-                        typename PipelineKV::PipelineState& kv_state,
-                        char* smem) {
+  CUTE_DEVICE void operator()(
+      const Params& /*params*/,
+      const TensorQ& gQ,     // (BLK_M, HEAD_DIM)
+      const TensorCQ& cQ,    // (BLK_M, HEAD_DIM) => (M, K)
+      const TensorK& gK,     // (BLK_N, HEAD_DIM, n)
+      const TensorV& gV,     // (BLK_N, HEAD_DIM, n)
+      const TensorCKV& cKV,  // (BLK_N, HEAD_DIM, n) => (N, K)
+      int tidx,
+      const ResidueMNK& residue_mnk,  // (M, N, K)
+      PipelineQ& q_pipeline,
+      typename PipelineQ::PipelineState& q_state,
+      PipelineKV& kv_pipeline,
+      typename PipelineKV::PipelineState& kv_state,
+      int n_block_min,
+      int n_block_max,
+      char* smem) {
     static_assert(is_gmem<TensorQ>::value, "Q tensor must be gmem resident.");
     static_assert(is_gmem<TensorK>::value, "K tensor must be gmem resident.");
     static_assert(is_gmem<TensorV>::value, "V tensor must be gmem resident.");
 
     static constexpr int kBlockM = get<0>(TileShape{});
     static constexpr int kBlockN = get<1>(TileShape{});
-
-    // const auto[q_idx, kv_head_idx] = blk_coord;
-    // const auto[q_packed_len, kv_len] = residue_mnk;
-    const int q_idx = get<0>(blk_coord);
-    const int kv_head_idx = get<1>(blk_coord);
-    const int q_packed_len = get<0>(residue_mnk);
-    const int kv_len = get<1>(residue_mnk);
-
-    const int sliding_window = LOCAL ? params.sliding_window : kv_len;
-    const auto& group_size = params.group_size;
-    const int q_len = q_packed_len / group_size;
-
-    // TODO: move this to caller in order to share with mma
-    const int diagonal = q_idx + kv_len - q_len;
-    // process kv in range: [kv_idx_min, kv_idx_max)
-    const int kv_idx_min = std::max(0, diagonal - sliding_window);
-    const int kv_idx_max = std::min(kv_len, diagonal + kBlockM);
-    const int n_block_min = LOCAL ? kv_idx_min / kBlockN : 0;
-    const int n_block_max = cute::ceil_div(kv_idx_max, kBlockN);
-
-    if (n_block_min >= n_block_max) {
-      // no kv blocks to process
-      return;
-    }
 
     // Construct shared memory tiles
     auto& ss = *reinterpret_cast<SharedStorage*>(smem);
@@ -244,16 +215,12 @@ struct Sm120CollectiveLoadCpAsyncWs {
     // produce query: [] => [q]
     q_pipeline.produce_acquire(q_state);
     produce_query();
-    // cp_async_fence();
-    // cp_async_wait<0>();
-    // __syncthreads();
     q_pipeline.producer_commit(q_state, cutlass::arch::cpasync_barrier_arrive);
     ++q_state;
 
     // produce key: [q] => [q, k]
     kv_pipeline.produce_acquire(kv_state);
     produce_key(n_block_max - 1);
-    // cp_async_fence();
     kv_pipeline.producer_commit(kv_state,
                                 cutlass::arch::cpasync_barrier_arrive);
     ++kv_state;
@@ -271,9 +238,6 @@ struct Sm120CollectiveLoadCpAsyncWs {
       } else {
         produce_value_no_oob(ni);
       }
-      // cp_async_fence();
-      // cp_async_wait<0>();
-      // __syncthreads();
       kv_pipeline.producer_commit(kv_state,
                                   cutlass::arch::cpasync_barrier_arrive);
       ++kv_state;
@@ -283,331 +247,10 @@ struct Sm120CollectiveLoadCpAsyncWs {
       if (ni > n_block_min) {
         produce_key_no_oob(ni - 1);
       }
-      // cp_async_fence();
-      // cp_async_wait<0>();
-      // __syncthreads();
       kv_pipeline.producer_commit(kv_state,
                                   cutlass::arch::cpasync_barrier_arrive);
       ++kv_state;
     }
-  }
-
-  // returns false if the block has been skipped
-  template <class TensorQ,
-            class TensorCQ,
-            class TensorK,
-            class TensorV,
-            class TensorCKV,
-            class TensorCMN,
-            class FrgTensor,
-            class Softmax,
-            class BlockCoord,
-            class ResidueMNK>
-  CUTE_DEVICE void operator()(
-      const Params& params,
-      const TensorQ& gQ,     // (BLK_M, HEAD_DIM)
-      const TensorCQ& cQ,    // (BLK_M, HEAD_DIM) => (M, K)
-      const TensorK& gK,     // (BLK_N, HEAD_DIM, n)
-      const TensorV& gV,     // (BLK_N, HEAD_DIM, n)
-      const TensorCKV& cKV,  // (BLK_N, HEAD_DIM, n) => (N, K)
-      const TensorCMN& cMN,  // (BLK_M, BLK_N, n) => (M, N)
-      FrgTensor& tOrO,       // (MMA, MMA_M, MMA_N)
-      Softmax& softmax,
-      int tidx,
-      const BlockCoord& blk_coord,
-      const ResidueMNK& residue_mnk,  // (M, N, K)
-      char* smem) {
-    static_assert(is_rmem<FrgTensor>::value,
-                  "Accum tensor must be rmem resident.");
-    static_assert(is_gmem<TensorQ>::value, "Q tensor must be gmem resident.");
-    static_assert(is_gmem<TensorK>::value, "K tensor must be gmem resident.");
-    static_assert(is_gmem<TensorV>::value, "V tensor must be gmem resident.");
-
-    static constexpr int kBlockM = get<0>(TileShape{});
-    static constexpr int kBlockN = get<1>(TileShape{});
-
-    const int q_idx = get<0>(blk_coord);
-    const int kv_head_idx = get<1>(blk_coord);
-    const int q_packed_len = get<0>(residue_mnk);
-    const int kv_len = get<1>(residue_mnk);
-
-    const int sliding_window = LOCAL ? params.sliding_window : kv_len;
-    const float logits_soft_cap = params.logits_soft_cap;
-    const float sm_scale = params.sm_scale;
-    const float sm_scale_log2 = params.sm_scale_log2;
-    const auto& group_size = params.group_size;
-    const int q_len = q_packed_len / group_size;
-
-    // Construct shared memory tiles
-    auto& ss = *reinterpret_cast<SharedStorage*>(smem);
-
-    // (BLK_M, HEAD_DIM), k-major
-    Tensor sQ = make_tensor(make_smem_ptr(ss.smem_q.data()), SmemLayoutQ{});
-    // (BLK_N, HEAD_DIM), k-major
-    Tensor sK = make_tensor(make_smem_ptr(ss.smem_k.data()), SmemLayoutK{});
-    Tensor sV = make_tensor(make_smem_ptr(ss.smem_v.data()), SmemLayoutV{});
-
-    // Tensor for V^t; used in GEMM-II.
-    // (HEAD_DIM, BLK_N), k-major
-    Tensor sVt = make_tensor(make_smem_ptr(ss.smem_vt.data()), SmemLayoutVt{});
-
-    // g2s tiled copy for qkv
-    GmemTiledCopyQ gmem_tiled_copy_Q;
-    GmemTiledCopyKV gmem_tiled_copy_KV;
-    auto gmem_thr_copy_Q = gmem_tiled_copy_Q.get_thread_slice(tidx);
-    auto gmem_thr_copy_KV = gmem_tiled_copy_KV.get_thread_slice(tidx);
-
-    // (CPY, CPY_N, CPY_K, n) => (N, K)
-    Tensor tGcKV = gmem_thr_copy_KV.partition_S(cKV);
-    // (CPY, CPY_N, CPY_K, n)
-    Tensor tGgK = gmem_thr_copy_KV.partition_S(gK);
-    Tensor tGgV = gmem_thr_copy_KV.partition_S(gV);
-
-    // (CPY, CPY_N, CPY_K)
-    Tensor tGsK = gmem_thr_copy_KV.partition_D(sK);
-    Tensor tGsV = gmem_thr_copy_KV.partition_D(sV);
-
-    const auto residue_mk = select<0, 2>(residue_mnk);
-    const auto residue_nk = select<1, 2>(residue_mnk);
-
-    auto produce_query = [&]() {
-      auto tGcQ = gmem_thr_copy_Q.partition_S(cQ);
-      auto tGgQ = gmem_thr_copy_Q.partition_S(gQ);
-      auto tGsQ = gmem_thr_copy_Q.partition_D(sQ);
-      safe_copy</*EVEN_MN=*/false, EVEN_K, /*ZFILL_MN=*/true, /*ZFILL_K=*/true>(
-          gmem_tiled_copy_Q, tGgQ, tGsQ, tGcQ, residue_mk);
-    };
-
-    auto produce_key = [&](int ni) {
-      // skip ZFILL_MN for key since Mask will mask out oob with -inf
-      safe_copy</*EVEN_N=*/false, EVEN_K, /*ZFILL_N=*/false, /*ZFILL_K=*/true>(
-          gmem_tiled_copy_KV,
-          tGgK(_, _, _, ni),
-          tGsK,
-          tGcKV(_, _, _, ni),
-          residue_nk);
-    };
-
-    // produce key without oob handling
-    auto produce_key_no_oob = [&](int ni) {
-      safe_copy</*EVEN_N=*/true, EVEN_K, /*ZFILL_N=*/false, /*ZFILL_K=*/false>(
-          gmem_tiled_copy_KV,
-          tGgK(_, _, _, ni),
-          tGsK,
-          tGcKV(_, _, _, ni),
-          residue_nk);
-    };
-
-    auto produce_value = [&](int ni) {
-      // skipping ZFILL_MN for v may cause nan issue
-      safe_copy</*EVEN_N=*/false, EVEN_K, /*ZFILL_N=*/true, /*ZFILL_K=*/true>(
-          gmem_tiled_copy_KV,
-          tGgV(_, _, _, ni),
-          tGsV,
-          tGcKV(_, _, _, ni),
-          residue_nk);
-    };
-
-    // produce value without oob handling
-    auto produce_value_no_oob = [&](int ni) {
-      safe_copy</*EVEN_N=*/true, EVEN_K, /*ZFILL_N=*/false, /*ZFILL_K=*/false>(
-          gmem_tiled_copy_KV,
-          tGgV(_, _, _, ni),
-          tGsV,
-          tGcKV(_, _, _, ni),
-          residue_nk);
-    };
-
-    TiledMma tiled_mma;
-    auto thr_mma = tiled_mma.get_slice(tidx);
-    // GEMM-I: S = Q@K.T
-    auto tSrQ = thr_mma.partition_fragment_A(sQ);  // (MMA,MMA_M,MMA_K)
-    auto tSrK = thr_mma.partition_fragment_B(sK);  // (MMA,MMA_N,MMA_K)
-
-    // s2r tiled copy for qkv
-    // copy query to rmem
-    SmemTiledCopyQ smem_tiled_copy_Q;
-    auto smem_thr_copy_Q = smem_tiled_copy_Q.get_thread_slice(tidx);
-    auto tSsQ = smem_thr_copy_Q.partition_S(sQ);
-    auto tSrQ_copy_view = smem_thr_copy_Q.retile_D(tSrQ);
-
-    SmemTiledCopyK smem_tiled_copy_K;
-    auto smem_thr_copy_K = smem_tiled_copy_K.get_thread_slice(tidx);
-    auto tSsK = smem_thr_copy_K.partition_S(sK);
-    auto tSrK_copy_view = smem_thr_copy_K.retile_D(tSrK);
-
-    // S = Q@K.T
-    // tSrAccS: (MMA,MMA_M,MMA_N)
-    auto compute_qk = [&](auto& tSrAccS) {
-      // prefetch key
-      cute::copy(
-          smem_tiled_copy_K, tSsK(_, _, _0{}), tSrK_copy_view(_, _, _0{}));
-
-      CUTE_UNROLL
-      for (int ki = 0; ki < size<2>(tSrQ); ++ki) {
-        // prefetch next key
-        if (ki != size<2>(tSrQ) - 1) {
-          const auto next_ki = ki + 1;
-          cute::copy(smem_tiled_copy_K,
-                     tSsK(_, _, next_ki),
-                     tSrK_copy_view(_, _, next_ki));
-        }
-        cute::gemm(tiled_mma, tSrQ(_, _, ki), tSrK(_, _, ki), tSrAccS);
-      }
-    };
-
-    // GEMM-II: O = softmax(S)@V
-    auto tOrVt = thr_mma.partition_fragment_B(sVt);  // (MMA,MMA_K,MMA_N)
-
-    SmemTiledCopyVt smem_tiled_copy_Vt;
-    auto smem_thr_copy_Vt = smem_tiled_copy_Vt.get_thread_slice(tidx);
-    auto tOsVt = smem_thr_copy_Vt.partition_S(sVt);
-    auto tOrVt_copy_view = smem_thr_copy_Vt.retile_D(tOrVt);
-
-    // O = softmax(S)*V
-    // tSrAccS: (MMA,MMA_M,MMA_N)
-    // tOrAccO: (MMA,MMA_M,MMA_K)
-    auto compute_sv = [&](const auto& tSrAccS, auto& tOrAccO) {
-      // cast scores from Accumulator to Element
-      auto tSrS = make_tensor_like<Element>(tSrAccS);
-      fast_cast(tSrAccS, tSrS);
-
-      // convert layout from gemm-I C to gemm-II A
-      auto tOrS =
-          make_tensor(tSrS.data(), LayoutConvertor::to_mma_a(tSrS.layout()));
-
-      // prefetch V^t
-      cute::copy(
-          smem_tiled_copy_Vt, tOsVt(_, _, _0{}), tOrVt_copy_view(_, _, _0{}));
-      CUTE_UNROLL
-      for (int ki = 0; ki < size<2>(tOrS); ++ki) {
-        // prefetch next V^t
-        if (ki != size<2>(tOrS) - 1) {
-          const auto next_ki = ki + 1;
-          cute::copy(smem_tiled_copy_Vt,
-                     tOsVt(_, _, next_ki),
-                     tOrVt_copy_view(_, _, next_ki));
-        }
-        cute::gemm(tiled_mma, tOrS(_, _, ki), tOrVt(_, _, ki), tOrAccO);
-      }
-    };
-
-    auto tOrO_mn =
-        make_tensor(tOrO.data(), LayoutConvertor::to_mn(tOrO.layout()));
-
-    const int diagonal = q_idx + kv_len - q_len;
-    // process kv in range: [kv_idx_min, kv_idx_max)
-    const int kv_idx_min = std::max(0, diagonal - sliding_window);
-    const int kv_idx_max = std::min(kv_len, diagonal + kBlockM);
-    const int n_block_min = LOCAL ? kv_idx_min / kBlockN : 0;
-    const int n_block_max = cute::ceil_div(kv_idx_max, kBlockN);
-
-    if (n_block_min >= n_block_max) {
-      // no kv blocks to process
-      return;
-    }
-
-    auto apply_logits_soft_cap = [&](auto& tSrAccS) {
-      if constexpr (SOFT_CAP) {
-        CUTE_UNROLL
-        for (int i = 0; i < size(tSrAccS); ++i) {
-          tSrAccS(i) = tanh(tSrAccS(i) * logits_soft_cap);
-        }
-      }
-    };
-
-    // ###############  Prologue  ###############
-    // produce query: [] => [q]
-    produce_query();
-    cp_async_fence();
-
-    // wait g2s copy done for query
-    cp_async_wait<0>();
-    __syncthreads();
-
-    // copy query from smem to rmem
-    cute::copy(smem_tiled_copy_Q, tSsQ, tSrQ_copy_view);
-    // wait s2r copy done for query
-    __syncthreads();
-
-    // produce key: [q] => [q, k]
-    produce_key(n_block_max - 1);
-    cp_async_fence();
-
-    // ###############  Mainloop  ###############
-    constexpr int n_oob_mask = cute::ceil_div(kBlockM, kBlockN) + 1;
-    const int n_blocks = n_block_max - n_block_min;
-
-    // attention score accumulator, (MMA, MMA_M, MMA_N)
-    auto tSrS = partition_fragment_C(tiled_mma, Shape<BLK_M, BLK_N>{});
-    // ((2, MMA_M), (2, MMA_N))
-    auto tSrS_mn =
-        make_tensor(tSrS.data(), LayoutConvertor::to_mn(tSrS.layout()));
-
-    // (MMA, MMA_M, MMA_N, n)
-    auto tScMN = thr_mma.partition_C(cMN);
-    // ((2, MMA_M), (2, MMA_N), n) => (M, N)
-    auto tScMN_mn =
-        make_tensor(tScMN.data(), LayoutConvertor::to_mn(tScMN.layout()));
-
-    constexpr int kRowsPerThr = kRowsPerMMA * size<1>(tSrS);
-    using Mask = Mask<kRowsPerThr, ALIBI, LOCAL>;
-    Mask mask(q_len, kv_len, group_size, sliding_window);
-    if constexpr (ALIBI) {
-      const auto tScS_mn = tScMN_mn(_, _, _0{});
-      mask.init_alibi(tScS_mn, kv_head_idx, sm_scale, params.alibi_slopes_ptr);
-    }
-
-    CUTE_NO_UNROLL
-    for (int i = 0; i < n_blocks; ++i) {
-      const int ni = n_block_max - 1 - i;
-      clear(tSrS);
-
-      // wait key, queue: [q, k] => []
-      cp_async_wait<0>();
-      __syncthreads();
-
-      // produce value, [] => [v]
-      if (i == 0) {
-        produce_value(ni);
-      } else {
-        produce_value_no_oob(ni);
-      }
-      cp_async_fence();
-
-      // 1> S = Q@K.T
-      compute_qk(tSrS);
-
-      // wait value, [v] => []
-      cp_async_wait<0>();
-      __syncthreads();
-
-      if constexpr (SOFT_CAP) {
-        apply_logits_soft_cap(tSrS);
-      }
-
-      // apply mask
-      // ((2, MMA_M), (2, MMA_N)) => (M, N)
-      const auto tScS_mn = tScMN_mn(_, _, ni);
-      if (i < n_oob_mask) {
-        mask.template apply</*OOB_MASK=*/true>(tSrS_mn, tScS_mn);
-      } else {
-        mask.template apply</*OOB_MASK=*/false>(tSrS_mn, tScS_mn);
-      }
-      softmax.rescale(tSrS_mn, tOrO_mn);
-
-      // produce next key: [] => [k]
-      if (ni > n_block_min) {
-        produce_key_no_oob(ni - 1);
-      }
-      cp_async_fence();
-
-      // 2> O = softmax(S)*V
-      compute_sv(tSrS, tOrO);
-    }
-
-    // normalize output: o /= rowsum
-    softmax.finalize(tOrO_mn);
   }
 };
 

--- a/src/kernels/attention/sm120_collective_mha.cuh
+++ b/src/kernels/attention/sm120_collective_mha.cuh
@@ -1,0 +1,464 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <cute/config.hpp>
+#include <cute/container/array_aligned.hpp>
+#include <cute/layout.hpp>
+#include <cute/tensor.hpp>
+
+#include "fast_cast.cuh"
+#include "layout_convertor.h"
+#include "mask.h"
+#include "safe_copy.h"
+
+namespace llm {
+
+using namespace cute;
+
+template <class TileShape_,
+          class Element_,
+          int HeadDim_,
+          bool EVEN_K,
+          bool ALIBI,
+          bool SOFT_CAP,
+          bool LOCAL>
+struct Sm120CollectiveMha {
+  // TODO: multiple stages
+  using TileShape = TileShape_;
+  using Element = Element_;
+  using ElementAccum = float;
+
+  static constexpr int kHeadDim = HeadDim_;
+  static constexpr int kBlockM = get<0>(TileShape{});
+  static constexpr int kBlockN = get<1>(TileShape{});
+  static constexpr int kBlockK = get<2>(TileShape{});
+
+  static_assert(kBlockK == 32 || kBlockK == 64);
+  static_assert(kHeadDim % kBlockK == 0);
+
+  using BLK_M = Int<kBlockM>;
+  using BLK_N = Int<kBlockN>;
+  using BLK_K = Int<kBlockK>;
+  using HEAD_DIM = Int<kHeadDim>;
+
+  // TiledMMA (64x16x16) for gemm-I and gemm-II
+  using MMA_Atom_ =
+      std::conditional_t<std::is_same_v<Element, cute::half_t>,
+                         MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>,
+                         MMA_Atom<SM80_16x8x16_F32BF16BF16F32_TN>>;
+  using TiledMma = TiledMMA<MMA_Atom_,
+                            Layout<Shape<_4, _1, _1>>,  // warp layout 4x1x1
+                            Tile<_64, _16, _16>>;       // Tile Shape 64x16x16
+
+  static constexpr int kRowsPerMMA = 2;
+  static constexpr int kMmaThreads = size(TiledMma{});
+
+  // Atom layout: (8, BLK_K):(BLK_K, 1) k-major
+  using SmemLayoutAtom_ =
+      decltype(composition(Swizzle<3, 3, 3>{},
+                           Layout<Shape<_8, BLK_K>, Stride<BLK_K, _1>>{}));
+
+  // Q smem: (BLK_M, HEAD_DIM)
+  using SmemLayoutQ =
+      decltype(tile_to_shape(SmemLayoutAtom_{}, Shape<BLK_M, HEAD_DIM>{}));
+
+  // KV smem: (BLK_N, HEAD_DIM)
+  using SmemLayoutK =
+      decltype(tile_to_shape(SmemLayoutAtom_{}, Shape<BLK_N, HEAD_DIM>{}));
+  using SmemLayoutV =
+      decltype(tile_to_shape(SmemLayoutAtom_{}, Shape<BLK_N, HEAD_DIM>{}));
+
+  // V^T smem: (HEAD_DIM, BLK_N)
+  using SmemLayoutVt = decltype(select<1, 0>(SmemLayoutV{}));
+
+  // Thr layout for gmem copy
+  using GmemCopyThrLayout_ =
+      std::conditional_t<kBlockK == 32,
+                         Layout<Shape<_32, _4>, Stride<_4, _1>>,
+                         Layout<Shape<_16, _8>, Stride<_8, _1>>>;
+
+  // g2s tiled copy for q
+  using GmemTiledCopyQ = decltype(make_tiled_copy(
+      Copy_Atom<SM80_CP_ASYNC_CACHEGLOBAL<cute::uint128_t>, Element>{},
+      GmemCopyThrLayout_{},    // Thr layout: (_16,_8)/(_32, _4)
+      Layout<Shape<_1, _8>>{}  // Val layout: 8 vals per read
+      ));
+
+  // g2s tiled copy for kv
+  using GmemTiledCopyKV = GmemTiledCopyQ;
+
+  // s2r tiled copy for gemm-I
+  using SmemTiledCopyQ =
+      decltype(make_tiled_copy_A(Copy_Atom<SM75_U32x4_LDSM_N, Element>{},
+                                 TiledMma{}));
+  using SmemTiledCopyK =
+      decltype(make_tiled_copy_B(Copy_Atom<SM75_U32x4_LDSM_N, Element>{},
+                                 TiledMma{}));
+
+  // s2r tiled copy for gemm-II
+  using SmemTiledCopyVt =
+      decltype(make_tiled_copy_B(Copy_Atom<SM75_U16x8_LDSM_T, Element>{},
+                                 TiledMma{}));
+
+  struct SharedStorage : cute::aligned_struct<128> {
+    union {
+      cute::array_aligned<Element, cute::cosize_v<SmemLayoutQ>> smem_q;
+      struct {
+        cute::array_aligned<Element, cute::cosize_v<SmemLayoutK>> smem_k;
+        union {
+          cute::array_aligned<Element, cute::cosize_v<SmemLayoutV>> smem_v;
+          cute::array_aligned<Element, cute::cosize_v<SmemLayoutVt>> smem_vt;
+        };
+      };
+    };
+  };
+
+  // Host side arguments
+  struct Arguments {
+    // mask
+    int sliding_window = -1;
+
+    // softcap
+    float logits_soft_cap = 0.0;
+
+    // softmax scaling
+    float sm_scale = 1.0;
+    float sm_scale_log2 = 0.0;
+
+    // alibi: (n_heads)
+    const float* __restrict__ alibi_slopes_ptr = nullptr;
+
+    FastDivmod group_size;
+  };
+
+  // Device side params
+  using Params = Arguments;
+
+  // Convert host side arguments to device side params
+  static Params to_underlying_arguments(Arguments const& args) {
+    // no convertion needed.
+    return args;
+  }
+
+  // returns false if the block has been skipped
+  template <class TensorQ,
+            class TensorCQ,
+            class TensorK,
+            class TensorV,
+            class TensorCKV,
+            class TensorCMN,
+            class FrgTensor,
+            class Softmax,
+            class BlockCoord,
+            class ResidueMNK>
+  CUTE_DEVICE void operator()(
+      const Params& params,
+      const TensorQ& gQ,     // (BLK_M, HEAD_DIM)
+      const TensorCQ& cQ,    // (BLK_M, HEAD_DIM) => (M, K)
+      const TensorK& gK,     // (BLK_N, HEAD_DIM, n)
+      const TensorV& gV,     // (BLK_N, HEAD_DIM, n)
+      const TensorCKV& cKV,  // (BLK_N, HEAD_DIM, n) => (N, K)
+      const TensorCMN& cMN,  // (BLK_M, BLK_N, n) => (M, N)
+      FrgTensor& tOrO,       // (MMA, MMA_M, MMA_N)
+      Softmax& softmax,
+      int tidx,
+      const BlockCoord& blk_coord,
+      const ResidueMNK& residue_mnk,  // (M, N, K)
+      char* smem) {
+    static_assert(is_rmem<FrgTensor>::value,
+                  "Accum tensor must be rmem resident.");
+    static_assert(is_gmem<TensorQ>::value, "Q tensor must be gmem resident.");
+    static_assert(is_gmem<TensorK>::value, "K tensor must be gmem resident.");
+    static_assert(is_gmem<TensorV>::value, "V tensor must be gmem resident.");
+
+    static constexpr int kBlockM = get<0>(TileShape{});
+    static constexpr int kBlockN = get<1>(TileShape{});
+
+    const int q_idx = get<0>(blk_coord);
+    const int kv_head_idx = get<1>(blk_coord);
+    const int q_packed_len = get<0>(residue_mnk);
+    const int kv_len = get<1>(residue_mnk);
+
+    const int sliding_window = LOCAL ? params.sliding_window : kv_len;
+    const float logits_soft_cap = params.logits_soft_cap;
+    const float sm_scale = params.sm_scale;
+    const float sm_scale_log2 = params.sm_scale_log2;
+    const auto& group_size = params.group_size;
+    const int q_len = q_packed_len / group_size;
+
+    // Construct shared memory tiles
+    auto& ss = *reinterpret_cast<SharedStorage*>(smem);
+
+    // (BLK_M, HEAD_DIM), k-major
+    Tensor sQ = make_tensor(make_smem_ptr(ss.smem_q.data()), SmemLayoutQ{});
+    // (BLK_N, HEAD_DIM), k-major
+    Tensor sK = make_tensor(make_smem_ptr(ss.smem_k.data()), SmemLayoutK{});
+    Tensor sV = make_tensor(make_smem_ptr(ss.smem_v.data()), SmemLayoutV{});
+
+    // Tensor for V^t; used in GEMM-II.
+    // (HEAD_DIM, BLK_N), k-major
+    Tensor sVt = make_tensor(make_smem_ptr(ss.smem_vt.data()), SmemLayoutVt{});
+
+    // g2s tiled copy for qkv
+    GmemTiledCopyQ gmem_tiled_copy_Q;
+    GmemTiledCopyKV gmem_tiled_copy_KV;
+    auto gmem_thr_copy_Q = gmem_tiled_copy_Q.get_thread_slice(tidx);
+    auto gmem_thr_copy_KV = gmem_tiled_copy_KV.get_thread_slice(tidx);
+
+    // (CPY, CPY_N, CPY_K, n) => (N, K)
+    Tensor tGcKV = gmem_thr_copy_KV.partition_S(cKV);
+    // (CPY, CPY_N, CPY_K, n)
+    Tensor tGgK = gmem_thr_copy_KV.partition_S(gK);
+    Tensor tGgV = gmem_thr_copy_KV.partition_S(gV);
+
+    // (CPY, CPY_N, CPY_K)
+    Tensor tGsK = gmem_thr_copy_KV.partition_D(sK);
+    Tensor tGsV = gmem_thr_copy_KV.partition_D(sV);
+
+    const auto residue_mk = select<0, 2>(residue_mnk);
+    const auto residue_nk = select<1, 2>(residue_mnk);
+
+    auto produce_query = [&]() {
+      auto tGcQ = gmem_thr_copy_Q.partition_S(cQ);
+      auto tGgQ = gmem_thr_copy_Q.partition_S(gQ);
+      auto tGsQ = gmem_thr_copy_Q.partition_D(sQ);
+      safe_copy</*EVEN_MN=*/false, EVEN_K, /*ZFILL_MN=*/true, /*ZFILL_K=*/true>(
+          gmem_tiled_copy_Q, tGgQ, tGsQ, tGcQ, residue_mk);
+    };
+
+    auto produce_key = [&](int ni) {
+      // skip ZFILL_MN for key since Mask will mask out oob with -inf
+      safe_copy</*EVEN_N=*/false, EVEN_K, /*ZFILL_N=*/false, /*ZFILL_K=*/true>(
+          gmem_tiled_copy_KV,
+          tGgK(_, _, _, ni),
+          tGsK,
+          tGcKV(_, _, _, ni),
+          residue_nk);
+    };
+
+    // produce key without oob handling
+    auto produce_key_no_oob = [&](int ni) {
+      safe_copy</*EVEN_N=*/true, EVEN_K, /*ZFILL_N=*/false, /*ZFILL_K=*/false>(
+          gmem_tiled_copy_KV,
+          tGgK(_, _, _, ni),
+          tGsK,
+          tGcKV(_, _, _, ni),
+          residue_nk);
+    };
+
+    auto produce_value = [&](int ni) {
+      // skipping ZFILL_MN for v may cause nan issue
+      safe_copy</*EVEN_N=*/false, EVEN_K, /*ZFILL_N=*/true, /*ZFILL_K=*/true>(
+          gmem_tiled_copy_KV,
+          tGgV(_, _, _, ni),
+          tGsV,
+          tGcKV(_, _, _, ni),
+          residue_nk);
+    };
+
+    // produce value without oob handling
+    auto produce_value_no_oob = [&](int ni) {
+      safe_copy</*EVEN_N=*/true, EVEN_K, /*ZFILL_N=*/false, /*ZFILL_K=*/false>(
+          gmem_tiled_copy_KV,
+          tGgV(_, _, _, ni),
+          tGsV,
+          tGcKV(_, _, _, ni),
+          residue_nk);
+    };
+
+    TiledMma tiled_mma;
+    auto thr_mma = tiled_mma.get_slice(tidx);
+    // GEMM-I: S = Q@K.T
+    auto tSrQ = thr_mma.partition_fragment_A(sQ);  // (MMA,MMA_M,MMA_K)
+    auto tSrK = thr_mma.partition_fragment_B(sK);  // (MMA,MMA_N,MMA_K)
+
+    // s2r tiled copy for qkv
+    // copy query to rmem
+    SmemTiledCopyQ smem_tiled_copy_Q;
+    auto smem_thr_copy_Q = smem_tiled_copy_Q.get_thread_slice(tidx);
+    auto tSsQ = smem_thr_copy_Q.partition_S(sQ);
+    auto tSrQ_copy_view = smem_thr_copy_Q.retile_D(tSrQ);
+
+    SmemTiledCopyK smem_tiled_copy_K;
+    auto smem_thr_copy_K = smem_tiled_copy_K.get_thread_slice(tidx);
+    auto tSsK = smem_thr_copy_K.partition_S(sK);
+    auto tSrK_copy_view = smem_thr_copy_K.retile_D(tSrK);
+
+    // S = Q@K.T
+    // tSrAccS: (MMA,MMA_M,MMA_N)
+    auto compute_qk = [&](auto& tSrAccS) {
+      // prefetch key
+      cute::copy(
+          smem_tiled_copy_K, tSsK(_, _, _0{}), tSrK_copy_view(_, _, _0{}));
+
+      CUTE_UNROLL
+      for (int ki = 0; ki < size<2>(tSrQ); ++ki) {
+        // prefetch next key
+        if (ki != size<2>(tSrQ) - 1) {
+          const auto next_ki = ki + 1;
+          cute::copy(smem_tiled_copy_K,
+                     tSsK(_, _, next_ki),
+                     tSrK_copy_view(_, _, next_ki));
+        }
+        cute::gemm(tiled_mma, tSrQ(_, _, ki), tSrK(_, _, ki), tSrAccS);
+      }
+    };
+
+    // GEMM-II: O = softmax(S)@V
+    auto tOrVt = thr_mma.partition_fragment_B(sVt);  // (MMA,MMA_K,MMA_N)
+
+    SmemTiledCopyVt smem_tiled_copy_Vt;
+    auto smem_thr_copy_Vt = smem_tiled_copy_Vt.get_thread_slice(tidx);
+    auto tOsVt = smem_thr_copy_Vt.partition_S(sVt);
+    auto tOrVt_copy_view = smem_thr_copy_Vt.retile_D(tOrVt);
+
+    // O = softmax(S)*V
+    // tSrAccS: (MMA,MMA_M,MMA_N)
+    // tOrAccO: (MMA,MMA_M,MMA_K)
+    auto compute_sv = [&](const auto& tSrAccS, auto& tOrAccO) {
+      // cast scores from Accumulator to Element
+      auto tSrS = make_tensor_like<Element>(tSrAccS);
+      fast_cast(tSrAccS, tSrS);
+
+      // convert layout from gemm-I C to gemm-II A
+      auto tOrS =
+          make_tensor(tSrS.data(), LayoutConvertor::to_mma_a(tSrS.layout()));
+
+      // prefetch V^t
+      cute::copy(
+          smem_tiled_copy_Vt, tOsVt(_, _, _0{}), tOrVt_copy_view(_, _, _0{}));
+      CUTE_UNROLL
+      for (int ki = 0; ki < size<2>(tOrS); ++ki) {
+        // prefetch next V^t
+        if (ki != size<2>(tOrS) - 1) {
+          const auto next_ki = ki + 1;
+          cute::copy(smem_tiled_copy_Vt,
+                     tOsVt(_, _, next_ki),
+                     tOrVt_copy_view(_, _, next_ki));
+        }
+        cute::gemm(tiled_mma, tOrS(_, _, ki), tOrVt(_, _, ki), tOrAccO);
+      }
+    };
+
+    auto tOrO_mn =
+        make_tensor(tOrO.data(), LayoutConvertor::to_mn(tOrO.layout()));
+
+    const int diagonal = q_idx + kv_len - q_len;
+    // process kv in range: [kv_idx_min, kv_idx_max)
+    const int kv_idx_min = std::max(0, diagonal - sliding_window);
+    const int kv_idx_max = std::min(kv_len, diagonal + kBlockM);
+    const int n_block_min = LOCAL ? kv_idx_min / kBlockN : 0;
+    const int n_block_max = cute::ceil_div(kv_idx_max, kBlockN);
+
+    if (n_block_min >= n_block_max) {
+      // no kv blocks to process
+      return;
+    }
+
+    auto apply_logits_soft_cap = [&](auto& tSrAccS) {
+      if constexpr (SOFT_CAP) {
+        CUTE_UNROLL
+        for (int i = 0; i < size(tSrAccS); ++i) {
+          tSrAccS(i) = tanh(tSrAccS(i) * logits_soft_cap);
+        }
+      }
+    };
+
+    // ###############  Prologue  ###############
+    // produce query: [] => [q]
+    produce_query();
+    cp_async_fence();
+
+    // wait g2s copy done for query
+    cp_async_wait<0>();
+    __syncthreads();
+
+    // copy query from smem to rmem
+    cute::copy(smem_tiled_copy_Q, tSsQ, tSrQ_copy_view);
+    // wait s2r copy done for query
+    __syncthreads();
+
+    // produce key: [q] => [q, k]
+    produce_key(n_block_max - 1);
+    cp_async_fence();
+
+    // ###############  Mainloop  ###############
+    constexpr int n_oob_mask = cute::ceil_div(kBlockM, kBlockN) + 1;
+    const int n_blocks = n_block_max - n_block_min;
+
+    // attention score accumulator, (MMA, MMA_M, MMA_N)
+    auto tSrS = partition_fragment_C(tiled_mma, Shape<BLK_M, BLK_N>{});
+    // ((2, MMA_M), (2, MMA_N))
+    auto tSrS_mn =
+        make_tensor(tSrS.data(), LayoutConvertor::to_mn(tSrS.layout()));
+
+    // (MMA, MMA_M, MMA_N, n)
+    auto tScMN = thr_mma.partition_C(cMN);
+    // ((2, MMA_M), (2, MMA_N), n) => (M, N)
+    auto tScMN_mn =
+        make_tensor(tScMN.data(), LayoutConvertor::to_mn(tScMN.layout()));
+
+    constexpr int kRowsPerThr = kRowsPerMMA * size<1>(tSrS);
+    using Mask = Mask<kRowsPerThr, ALIBI, LOCAL>;
+    Mask mask(q_len, kv_len, group_size, sliding_window);
+    if constexpr (ALIBI) {
+      const auto tScS_mn = tScMN_mn(_, _, _0{});
+      mask.init_alibi(tScS_mn, kv_head_idx, sm_scale, params.alibi_slopes_ptr);
+    }
+
+    CUTE_NO_UNROLL
+    for (int i = 0; i < n_blocks; ++i) {
+      const int ni = n_block_max - 1 - i;
+      clear(tSrS);
+
+      // wait key, queue: [q, k] => []
+      cp_async_wait<0>();
+      __syncthreads();
+
+      // produce value, [] => [v]
+      if (i == 0) {
+        produce_value(ni);
+      } else {
+        produce_value_no_oob(ni);
+      }
+      cp_async_fence();
+
+      // 1> S = Q@K.T
+      compute_qk(tSrS);
+
+      // wait value, [v] => []
+      cp_async_wait<0>();
+      __syncthreads();
+
+      if constexpr (SOFT_CAP) {
+        apply_logits_soft_cap(tSrS);
+      }
+
+      // apply mask
+      // ((2, MMA_M), (2, MMA_N)) => (M, N)
+      const auto tScS_mn = tScMN_mn(_, _, ni);
+      if (i < n_oob_mask) {
+        mask.template apply</*OOB_MASK=*/true>(tSrS_mn, tScS_mn);
+      } else {
+        mask.template apply</*OOB_MASK=*/false>(tSrS_mn, tScS_mn);
+      }
+      softmax.rescale(tSrS_mn, tOrO_mn);
+
+      // produce next key: [] => [k]
+      if (ni > n_block_min) {
+        produce_key_no_oob(ni - 1);
+      }
+      cp_async_fence();
+
+      // 2> O = softmax(S)*V
+      compute_sv(tSrS, tOrO);
+    }
+
+    // normalize output: o /= rowsum
+    softmax.finalize(tOrO_mn);
+  }
+};
+
+}  // namespace llm

--- a/src/kernels/attention/sm120_collective_mha.cuh
+++ b/src/kernels/attention/sm120_collective_mha.cuh
@@ -10,7 +10,6 @@
 
 #include "fast_cast.cuh"
 #include "layout_convertor.h"
-#include "mask.h"
 #include "safe_copy.h"
 
 namespace llm {
@@ -34,6 +33,9 @@ struct Sm120CollectiveMha {
   static constexpr int kBlockM = get<0>(TileShape{});
   static constexpr int kBlockN = get<1>(TileShape{});
   static constexpr int kBlockK = get<2>(TileShape{});
+
+  static constexpr bool kAlibi = ALIBI;
+  static constexpr bool kLocal = LOCAL;
 
   static_assert(kBlockK == 32 || kBlockK == 64);
   static_assert(kHeadDim % kBlockK == 0);
@@ -115,20 +117,8 @@ struct Sm120CollectiveMha {
 
   // Host side arguments
   struct Arguments {
-    // mask
-    int sliding_window = -1;
-
     // softcap
     float logits_soft_cap = 0.0;
-
-    // softmax scaling
-    float sm_scale = 1.0;
-    float sm_scale_log2 = 0.0;
-
-    // alibi: (n_heads)
-    const float* __restrict__ alibi_slopes_ptr = nullptr;
-
-    FastDivmod group_size;
   };
 
   // Device side params
@@ -149,21 +139,23 @@ struct Sm120CollectiveMha {
             class TensorCMN,
             class FrgTensor,
             class Softmax,
-            class BlockCoord,
+            class Mask,
             class ResidueMNK>
   CUTE_DEVICE void operator()(
       const Params& params,
-      const TensorQ& gQ,     // (BLK_M, HEAD_DIM)
-      const TensorCQ& cQ,    // (BLK_M, HEAD_DIM) => (M, K)
-      const TensorK& gK,     // (BLK_N, HEAD_DIM, n)
-      const TensorV& gV,     // (BLK_N, HEAD_DIM, n)
-      const TensorCKV& cKV,  // (BLK_N, HEAD_DIM, n) => (N, K)
-      const TensorCMN& cMN,  // (BLK_M, BLK_N, n) => (M, N)
-      FrgTensor& tOrO,       // (MMA, MMA_M, MMA_N)
+      const TensorQ& gQ,          // (BLK_M, HEAD_DIM)
+      const TensorCQ& cQ,         // (BLK_M, HEAD_DIM) => (M, K)
+      const TensorK& gK,          // (BLK_N, HEAD_DIM, n)
+      const TensorV& gV,          // (BLK_N, HEAD_DIM, n)
+      const TensorCKV& cKV,       // (BLK_N, HEAD_DIM, n) => (N, K)
+      const TensorCMN& tScMN_mn,  // ((2, MMA_M), (2, MMA_N), n) => (M, N)
+      FrgTensor& tOrO,            // (MMA, MMA_M, MMA_N)
       Softmax& softmax,
+      const Mask& mask,
       int tidx,
-      const BlockCoord& blk_coord,
       const ResidueMNK& residue_mnk,  // (M, N, K)
+      int n_block_min,
+      int n_block_max,
       char* smem) {
     static_assert(is_rmem<FrgTensor>::value,
                   "Accum tensor must be rmem resident.");
@@ -174,17 +166,7 @@ struct Sm120CollectiveMha {
     static constexpr int kBlockM = get<0>(TileShape{});
     static constexpr int kBlockN = get<1>(TileShape{});
 
-    const int q_idx = get<0>(blk_coord);
-    const int kv_head_idx = get<1>(blk_coord);
-    const int q_packed_len = get<0>(residue_mnk);
-    const int kv_len = get<1>(residue_mnk);
-
-    const int sliding_window = LOCAL ? params.sliding_window : kv_len;
-    const float logits_soft_cap = params.logits_soft_cap;
-    const float sm_scale = params.sm_scale;
-    const float sm_scale_log2 = params.sm_scale_log2;
-    const auto& group_size = params.group_size;
-    const int q_len = q_packed_len / group_size;
+    // assert(n_block_min < n_block_max);
 
     // Construct shared memory tiles
     auto& ss = *reinterpret_cast<SharedStorage*>(smem);
@@ -343,23 +325,11 @@ struct Sm120CollectiveMha {
     auto tOrO_mn =
         make_tensor(tOrO.data(), LayoutConvertor::to_mn(tOrO.layout()));
 
-    const int diagonal = q_idx + kv_len - q_len;
-    // process kv in range: [kv_idx_min, kv_idx_max)
-    const int kv_idx_min = std::max(0, diagonal - sliding_window);
-    const int kv_idx_max = std::min(kv_len, diagonal + kBlockM);
-    const int n_block_min = LOCAL ? kv_idx_min / kBlockN : 0;
-    const int n_block_max = cute::ceil_div(kv_idx_max, kBlockN);
-
-    if (n_block_min >= n_block_max) {
-      // no kv blocks to process
-      return;
-    }
-
     auto apply_logits_soft_cap = [&](auto& tSrAccS) {
       if constexpr (SOFT_CAP) {
         CUTE_UNROLL
         for (int i = 0; i < size(tSrAccS); ++i) {
-          tSrAccS(i) = tanh(tSrAccS(i) * logits_soft_cap);
+          tSrAccS(i) = tanh(tSrAccS(i) * params.logits_soft_cap);
         }
       }
     };
@@ -389,20 +359,6 @@ struct Sm120CollectiveMha {
     // ((2, MMA_M), (2, MMA_N))
     auto tSrS_mn =
         make_tensor(tSrS.data(), LayoutConvertor::to_mn(tSrS.layout()));
-
-    // (MMA, MMA_M, MMA_N, n)
-    auto tScMN = thr_mma.partition_C(cMN);
-    // ((2, MMA_M), (2, MMA_N), n) => (M, N)
-    auto tScMN_mn =
-        make_tensor(tScMN.data(), LayoutConvertor::to_mn(tScMN.layout()));
-
-    constexpr int kRowsPerThr = kRowsPerMMA * size<1>(tSrS);
-    using Mask = Mask<kRowsPerThr, ALIBI, LOCAL>;
-    Mask mask(q_len, kv_len, group_size, sliding_window);
-    if constexpr (ALIBI) {
-      const auto tScS_mn = tScMN_mn(_, _, _0{});
-      mask.init_alibi(tScS_mn, kv_head_idx, sm_scale, params.alibi_slopes_ptr);
-    }
 
     CUTE_NO_UNROLL
     for (int i = 0; i < n_blocks; ++i) {

--- a/src/kernels/attention/sm120_kernel_mha.cuh
+++ b/src/kernels/attention/sm120_kernel_mha.cuh
@@ -1,0 +1,301 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <cute/layout.hpp>
+#include <cute/tensor.hpp>
+
+#include "gather_tensor.hpp"
+#include "mha_params.h"
+#include "online_softmax.cuh"
+
+namespace llm {
+
+using namespace cute;
+
+namespace detail {
+
+template <typename Params>
+struct MHATile {
+  static_assert(cute::dependent_false<Params>, "not implemented");
+};
+
+// AttentionTile specialization for AttentionParams
+template <>
+struct MHATile<MHAParams> {
+  const MHAParams& params_;
+  const int batch_idx_;
+  const int kv_head_idx_;
+
+  CUTE_HOST_DEVICE MHATile(const MHAParams& params,
+                           int batch_idx,
+                           int kv_head_idx)
+      : params_(params), batch_idx_(batch_idx), kv_head_idx_(kv_head_idx) {}
+
+  // return the query/output tile: (q_len, head_dim)
+  template <typename Element>
+  CUTE_HOST_DEVICE auto get_qo_tile() const {
+    // (batch, seq, head, dim)
+
+    // packed all q/o in the same kv head group together
+    const auto head_base = kv_head_idx_ * params_.group_size;
+    auto packed_idx_to_coord = [this, head_base](int packed_idx) {
+      int idx, offset;
+      params_.group_size.divmod(packed_idx, idx, offset);
+      return make_coord(idx, head_base + offset);
+    };
+
+    const auto packed_len = params_.q_len * params_.group_size;
+    const auto q_offset = batch_idx_ * get<0>(params_.q_stride);
+    auto q = make_gather_tensor(
+        make_gmem_ptr((const Element*)params_.q_ptr + q_offset),
+        make_shape(packed_len, params_.head_dim),
+        make_stride(select<1, 2>(params_.q_stride), get<3>(params_.q_stride)),
+        packed_idx_to_coord);
+
+    const auto o_offset = batch_idx_ * get<0>(params_.o_stride);
+    auto o = make_gather_tensor(
+        make_gmem_ptr((Element*)params_.o_ptr + o_offset),
+        make_shape(packed_len, params_.head_dim),
+        make_stride(select<1, 2>(params_.o_stride), get<3>(params_.o_stride)),
+        packed_idx_to_coord);
+    return make_tuple(q, o);
+  }
+
+  // return the key/value tile: (kv_len, head_dim)
+  template <typename Element>
+  CUTE_HOST_DEVICE auto get_kv_tile() const {
+    // (batch, seq, kv_head, dim)
+    const auto k_offset = batch_idx_ * get<0>(params_.k_stride) +
+                          kv_head_idx_ * get<2>(params_.k_stride);
+    const auto v_offset = batch_idx_ * get<0>(params_.v_stride) +
+                          kv_head_idx_ * get<2>(params_.v_stride);
+    // k[batch_idx, :, kv_head_idx, :]
+    auto k =
+        make_tensor(make_gmem_ptr((const Element*)params_.k_ptr + k_offset),
+                    make_shape(params_.kv_len, params_.head_dim),
+                    select<1, 3>(params_.k_stride));
+    // v[batch_idx, :, kv_head_idx, :]
+    auto v =
+        make_tensor(make_gmem_ptr((const Element*)params_.v_ptr + v_offset),
+                    make_shape(params_.kv_len, params_.head_dim),
+                    select<1, 3>(params_.v_stride));
+    return make_tuple(k, v);
+  }
+};
+
+// paged KV cache + variable length sequence
+template <>
+struct MHATile<MHAPagedKVParams> {
+  // NOLINTNEXTLINE
+  const MHAPagedKVParams& params_;
+  const int batch_idx_;
+  const int kv_head_idx_;
+
+  CUTE_HOST_DEVICE MHATile(const MHAPagedKVParams& params,
+                           int batch_idx,
+                           int kv_head_idx)
+      : params_(params), batch_idx_(batch_idx), kv_head_idx_(kv_head_idx) {}
+
+  // return the query/output tile: (q_len, head_dim)
+  template <typename Element>
+  CUTE_HOST_DEVICE auto get_qo_tile() const {
+    const auto begin = params_.q_cu_lens[batch_idx_];
+    const auto qo_len = params_.q_cu_lens[batch_idx_ + 1] - begin;
+    const auto head_base = kv_head_idx_ * params_.group_size;
+    auto packed_idx_to_coord = [this, head_base](int packed_idx) {
+      int idx, offset;
+      params_.group_size.divmod(packed_idx, idx, offset);
+      return make_coord(idx, head_base + offset);
+    };
+
+    const auto packed_len = qo_len * params_.group_size;
+    const auto q_offset = begin * get<0>(params_.q_stride);
+    auto q = make_gather_tensor(
+        make_gmem_ptr((const Element*)params_.q_ptr + q_offset),
+        make_shape(packed_len, params_.head_dim),
+        make_stride(select<0, 1>(params_.q_stride), get<2>(params_.q_stride)),
+        packed_idx_to_coord);
+
+    const auto o_offset = begin * get<0>(params_.o_stride);
+    auto o = make_gather_tensor(
+        make_gmem_ptr((Element*)params_.o_ptr + o_offset),
+        make_shape(packed_len, params_.head_dim),
+        make_stride(select<0, 1>(params_.o_stride), get<2>(params_.o_stride)),
+        packed_idx_to_coord);
+    return make_tuple(q, o);
+  }
+
+  // return the key/value tile: (kv_len, head_dim)
+  template <typename Element>
+  CUTE_HOST_DEVICE auto get_kv_tile() const {
+    const auto kv_len =
+        params_.kv_cu_lens[batch_idx_ + 1] - params_.kv_cu_lens[batch_idx_];
+
+    // map seq_idx to slot_idx
+    const int* block_table =
+        params_.block_table + params_.block_cu_lens[batch_idx_];
+    auto idx_to_slot = [block_table,
+                        shr = params_.block_shift_right,
+                        mask = params_.block_mask](int idx) {
+      return block_table[idx >> shr] + (idx & mask);
+    };
+
+    // v[:, kv_head_idx, :]
+    const auto k_offset = kv_head_idx_ * get<1>(params_.k_stride);
+    auto k = make_gather_tensor(
+        make_gmem_ptr((const Element*)params_.k_ptr + k_offset),
+        make_shape(kv_len, params_.head_dim),
+        select<0, 2>(params_.k_stride),
+        idx_to_slot);
+
+    // v[:, kv_head_idx, :]
+    const auto v_offset = kv_head_idx_ * get<1>(params_.v_stride);
+    auto v = make_gather_tensor(
+        make_gmem_ptr((const Element*)params_.v_ptr + v_offset),
+        make_shape(kv_len, params_.head_dim),
+        select<0, 2>(params_.v_stride),
+        idx_to_slot);
+    return make_tuple(k, v);
+  }
+};
+}  // namespace detail
+
+template <class CollectiveMainloop_,
+          class CollectiveEpilogue_,
+          class TileScheduler_>
+class Sm120KernelMha {
+ public:
+  using CollectiveMainloop = CollectiveMainloop_;
+  using CollectiveEpilogue = CollectiveEpilogue_;
+  using TileScheduler = TileScheduler_;
+
+  using TiledMma = typename CollectiveMainloop::TiledMma;
+
+  using Element = typename CollectiveMainloop::Element;
+  using BLK_M = typename CollectiveMainloop::BLK_M;
+  using BLK_N = typename CollectiveMainloop::BLK_N;
+  using HEAD_DIM = typename CollectiveMainloop::HEAD_DIM;
+
+  static constexpr int kBlockM = CollectiveMainloop::kBlockM;
+
+  static constexpr int kRowsPerMMA = CollectiveMainloop::kRowsPerMMA;
+
+  static constexpr int kSharedStorageSize =
+      cute::max(sizeof(typename CollectiveMainloop::SharedStorage),
+                sizeof(typename CollectiveEpilogue::SharedStorage));
+
+  static constexpr int kMmaThreads = CollectiveMainloop::kMmaThreads;
+
+  // Kernel params
+  using MainloopParams = typename CollectiveMainloop::Params;
+  using EpilogueParams = typename CollectiveEpilogue::Params;
+  using TileSchedulerParams = typename TileScheduler::Params;
+
+  // returns grid and block shape for kernel launch
+  using TileSchedulerArgs = typename TileScheduler::Arguments;
+  static dim3 get_grid_shape(TileSchedulerArgs const& args) {
+    return TileScheduler::get_grid_shape(args);
+  }
+  static dim3 get_block_shape() { return kMmaThreads; }
+
+  template <class Params>
+  CUTE_DEVICE void operator()(const Params& params,
+                              const TileSchedulerParams& scheduler_params,
+                              char* smem) {
+    CollectiveMainloop mha;
+    CollectiveEpilogue epilogue;
+    TileScheduler scheduler(scheduler_params);
+
+    // construct params
+    MainloopParams mainloop_params{params.sliding_window,
+                                   params.logits_soft_cap,
+                                   params.sm_scale,
+                                   params.sm_scale_log2,
+                                   params.alibi_slopes_ptr,
+                                   params.group_size};
+    EpilogueParams epilogue_params;
+
+    // process each block
+    const auto& group_size = params.group_size;
+    for (const auto block_coord : scheduler) {
+      // block coord: (batch_idx, m_block_idx, kv_head_idx)
+      const auto [batch_idx, m_block_idx, kv_head_idx] = block_coord;
+      const auto tidx = threadIdx.x;
+
+      // (q_packed_len, HEAD_DIM)
+      detail::MHATile<Params> tile(params, batch_idx, kv_head_idx);
+      auto [Q, O] = tile.template get_qo_tile<Element>();
+      // (kv_len, HEAD_DIM)
+      auto [K, V] = tile.template get_kv_tile<Element>();
+
+      // problem shape
+      const int q_packed_len = size<0>(Q);
+      const int kv_len = size<0>(K);
+      const int m_block_base = m_block_idx * kBlockM;
+      if (m_block_base >= q_packed_len) {
+        // m out of bound, skip this block
+        continue;
+      }
+
+      const int q_idx = m_block_base / group_size;
+      const auto residue_mnk =
+          make_tuple(q_packed_len, kv_len, params.head_dim);
+
+      // (BLK_M, HEAD_DIM)
+      Tensor gQ = local_tile(
+          Q, Shape<BLK_M, HEAD_DIM>{}, make_coord(m_block_idx, _0{}));
+      Tensor gO = local_tile(
+          O, Shape<BLK_M, HEAD_DIM>{}, make_coord(m_block_idx, _0{}));
+      // (BLK_M, HEAD_DIM) => (M, K)
+      Tensor cQ = local_tile(make_identity_tensor(Q.shape()),
+                             Shape<BLK_M, HEAD_DIM>{},
+                             make_coord(m_block_idx, _0{}));
+
+      // (BLK_N, HEAD_DIM, n)
+      Tensor gK = local_tile(K, Shape<BLK_N, HEAD_DIM>{}, make_coord(_, _0{}));
+      Tensor gV = local_tile(V, Shape<BLK_N, HEAD_DIM>{}, make_coord(_, _0{}));
+      // (BLK_N, HEAD_DIM, n) => (N, K)
+      Tensor cKV = local_tile(make_identity_tensor(K.shape()),
+                              Shape<BLK_N, HEAD_DIM>{},
+                              make_coord(_, _0{}));
+
+      // (BLK_M, BLK_N, n) => (M, N)
+      Tensor cMN =
+          local_tile(make_identity_tensor(make_shape(q_packed_len, kv_len)),
+                     Shape<BLK_M, BLK_N>{},
+                     make_coord(m_block_idx, _));
+
+      TiledMma tiled_mma;
+      // accumulator: MMA,MMA_M,MMA_K)
+      auto tOrAccO = partition_fragment_C(tiled_mma, Shape<BLK_M, HEAD_DIM>{});
+      clear(tOrAccO);
+
+      constexpr int kRowsPerThr = kRowsPerMMA * size<1>(tOrAccO);
+      OnlineSoftmax<kRowsPerThr> softmax(params.sm_scale_log2);
+
+      // mainloop
+      const auto blk_coord = make_coord(q_idx, kv_head_idx);
+      mha(mainloop_params,
+          gQ,
+          cQ,
+          gK,
+          gV,
+          cKV,
+          cMN,
+          tOrAccO,
+          softmax,
+          tidx,
+          blk_coord,
+          residue_mnk,
+          smem);
+
+      // epilogue
+      epilogue(
+          epilogue_params, tOrAccO, tiled_mma, gO, cQ, tidx, residue_mnk, smem);
+    }
+  }
+};
+
+}  // namespace llm

--- a/src/kernels/attention/sm120_mha_dispatch.cuh
+++ b/src/kernels/attention/sm120_mha_dispatch.cuh
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cute/int_tuple.hpp>
+#include <cute/layout.hpp>
+
+#include "static_dispatch.h"
+
+namespace llm {
+// forward declaration
+template <typename Dtype,
+          int HEAD_DIM,
+          bool EVEN_K,
+          bool ALIBI,
+          bool SOFT_CAP,
+          bool LOCAL,
+          typename Params>
+void sm120_launch_mha_kernel(const Params& params, cudaStream_t stream);
+
+// user-facing function to run the attention kernel
+template <typename Dtype, int HEAD_DIM, typename Params>
+void sm120_run_mha(Params& params, cudaStream_t stream = nullptr) {
+  // normalize params that for performance optimization
+  params.normalize();
+
+  // dispatch to proper kernel instantiation based on params
+  DISPATCH_BOOL(params.head_dim == HEAD_DIM, EVEN_K, [&] {
+    DISPATCH_BOOL(params.alibi_slopes_ptr != nullptr, ALIBI, [&] {
+      DISPATCH_BOOL(params.logits_soft_cap > 0, SOFT_CAP, [&] {
+        DISPATCH_BOOL(params.sliding_window >= 0, LOCAL, [&] {
+          sm120_launch_mha_kernel<Dtype,
+                                  HEAD_DIM,
+                                  EVEN_K,
+                                  ALIBI,
+                                  SOFT_CAP,
+                                  LOCAL,
+                                  Params>(params, stream);
+        });
+      });
+    });
+  });
+}
+
+}  // namespace llm

--- a/src/kernels/attention/sm120_mha_launch.cuh
+++ b/src/kernels/attention/sm120_mha_launch.cuh
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <cute/layout.hpp>
+#include <cute/tensor.hpp>
+
+#include "sm120_collective_epilogue.cuh"
+#include "sm120_collective_mha.cuh"
+#include "sm120_kernel_mha.cuh"
+#include "tile_scheduler.cuh"
+
+namespace llm {
+
+namespace detail {
+/// Generic kernel template.
+template <typename Operator, typename Params>
+__global__ __launch_bounds__(Operator::kMmaThreads) void device_kernel(
+    __grid_constant__ const Params params,
+    __grid_constant__ const typename Operator::TileSchedulerParams
+        scheduler_params) {
+  extern __shared__ char smem[];
+  Operator op;
+  op(params, scheduler_params, smem);
+}
+}  // namespace detail
+
+template <typename Dtype,
+          int HEAD_DIM,
+          bool EVEN_K,
+          bool ALIBI,
+          bool SOFT_CAP,
+          bool LOCAL,
+          typename Params>
+void sm120_launch_mha_kernel(const Params& params, cudaStream_t stream) {
+  const auto batch_size = params.batch_size;
+  const auto n_kv_heads = params.n_kv_heads;
+  const auto max_q_packed_len = params.max_q_len * params.group_size;
+
+  // TODO: tune block shape MNK based on the head dim and smem size
+  // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications-technical-specifications-per-compute-capability
+  // SM           | 7.0 | 7.2 | 7.5 | 8.0 | 8.6 | 8.7 | 8.9 | 9.0 | 10.x | 12.0|
+  // Max SMEM (KB)|     96    |  64 | 164 | 100 | 164 | 100 |     228    | 100 |
+  // valid dynamic shared memory sizes for different compute capabilities:
+  // * 7.0 | 7.2 : 0, 8, 16, 32, 64, 96
+  // * 7.5       : 0, 32, 64
+  // * 8.0 | 8.7 : 0, 8, 16, 32, 64, 100, 132, 164
+  // * 8.6 | 8.9 : 0, 8, 16, 32, 64, 100
+  // * 9.0 | 10.x: 0, 8, 16, 32, 64, 100, 132, 164, 196, 228
+  // * 12.0      : 0, 8, 16, 32, 64, 100
+  constexpr int BLK_M = 64;
+  constexpr int BLK_N = 64;
+  constexpr int BLK_K = HEAD_DIM % 64 == 0 ? 64 : 32;
+
+  using TileShape = Shape<Int<BLK_M>, Int<BLK_N>, Int<BLK_K>>;
+  using CollectiveMainloop = Sm120CollectiveMha<TileShape,
+                                                Dtype,
+                                                HEAD_DIM,
+                                                EVEN_K,
+                                                ALIBI,
+                                                SOFT_CAP,
+                                                LOCAL>;
+  using CollectiveEpilogue =
+      Sm120CollectiveEpilogue<TileShape, Dtype, HEAD_DIM, EVEN_K>;
+
+  // TODO: support persistent kernels
+  using TileScheduler = SingleTileScheduler;
+
+  const auto m_blocks = cute::ceil_div(max_q_packed_len, BLK_M);
+  typename TileScheduler::Arguments scheduler_args{
+      batch_size, m_blocks, n_kv_heads};
+  auto scheduler_params =
+      TileScheduler::to_underlying_arguments(scheduler_args);
+
+  using AttnKernel =
+      Sm120KernelMha<CollectiveMainloop, CollectiveEpilogue, TileScheduler>;
+
+  auto mha_kernel = detail::device_kernel<AttnKernel, Params>;
+
+  const auto smem_size = AttnKernel::kSharedStorageSize;
+  if (smem_size >= 48 * 1024) {
+    cudaFuncSetAttribute(
+        mha_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+  }
+
+  const dim3 grid = AttnKernel::get_grid_shape(scheduler_args);
+  const dim3 block = AttnKernel::get_block_shape();
+
+  mha_kernel<<<grid, block, smem_size, stream>>>(params, scheduler_params);
+  // TODO: check launch status
+}
+
+}  // namespace llm

--- a/src/kernels/attention/sm120_mha_test.cu
+++ b/src/kernels/attention/sm120_mha_test.cu
@@ -1,0 +1,166 @@
+#include <gtest/gtest.h>
+#include <torch/torch.h>
+
+#include <cstdint>
+
+#include "cute/layout.hpp"
+#include "mha_params.h"
+#include "mha_ref.h"
+#include "sm120_mha_dispatch.cuh"
+#include "sm120_mha_launch.cuh"  // IWYU pragma: keep
+
+namespace llm {
+#define DISPATCH_HEAD_DIM_(HEAD_DIM_V, HEAD_DIM_NAME, ...) \
+  [&] {                                                    \
+    if (HEAD_DIM_V <= 64) {                                \
+      constexpr static int HEAD_DIM_NAME = 64;             \
+      return __VA_ARGS__();                                \
+    } else {                                               \
+      assert(false);                                       \
+    }                                                      \
+  }()
+
+#define DISPATCH_TORCH_DTYPE_(TORCH_DTYPE, TYPE_NAME, ...) \
+  [&] {                                                    \
+    if (TORCH_DTYPE == torch::kHalf) {                     \
+      using TYPE_NAME = cute::half_t;                      \
+      return __VA_ARGS__();                                \
+    } else {                                               \
+      assert(false);                                       \
+    }                                                      \
+  }()
+
+namespace {
+torch::Tensor sm120_mha(
+    torch::Tensor query,  // [batch_size, q_len, n_heads, head_dim]
+    torch::Tensor key,    // [batch_size, kv_len, n_kv_heads, head_dim]
+    torch::Tensor value,  // [batch_size, kv_len, n_kv_heads, head_dim]
+    torch::optional<torch::Tensor> alibi_slopes,  //[n_heads]
+    float logits_soft_cap,
+    int32_t sliding_window,
+    int32_t max_q_len) {
+  const auto batch_size = query.size(0);
+  const auto q_len = query.size(-3);
+  const auto kv_len = key.size(-3);
+  const auto n_heads = query.size(-2);
+  const auto n_kv_heads = key.size(-2);
+  const auto head_dim = query.size(-1);
+
+  auto out = torch::empty_like(query);
+
+  const float sm_scale = 1.0 / sqrt(head_dim);
+
+  // construct attention params
+  MHAParams params;
+  params.q_ptr = query.const_data_ptr();
+  params.q_stride =
+      make_stride(query.stride(0), query.stride(1), query.stride(2), _1{});
+  params.k_ptr = key.const_data_ptr();
+  params.k_stride =
+      make_stride(key.stride(0), key.stride(1), key.stride(2), _1{});
+  params.v_ptr = value.const_data_ptr();
+  params.v_stride =
+      make_stride(value.stride(0), value.stride(1), value.stride(2), _1{});
+  params.o_ptr = out.mutable_data_ptr();
+  params.o_stride =
+      make_stride(out.stride(0), out.stride(1), out.stride(2), _1{});
+  params.alibi_slopes_ptr = alibi_slopes.has_value()
+                                ? alibi_slopes.value().const_data_ptr<float>()
+                                : nullptr;
+
+  params.batch_size = batch_size;
+  params.max_q_len = max_q_len;
+  params.n_heads = n_heads;
+  params.n_kv_heads = n_kv_heads;
+  params.q_len = q_len;
+  params.kv_len = kv_len;
+  params.head_dim = head_dim;
+  params.sm_scale = sm_scale;
+  params.logits_soft_cap = logits_soft_cap;
+  params.sliding_window = sliding_window;
+
+  DISPATCH_TORCH_DTYPE_(query.dtype(), DTYPE, [&] {
+    DISPATCH_HEAD_DIM_(
+        head_dim, HEAD_DIM, [&] { sm120_run_mha<DTYPE, HEAD_DIM>(params); });
+  });
+  return out;
+}
+
+}  // namespace
+
+class MHAKernelTest
+    : public ::testing::TestWithParam<std::tuple<torch::ScalarType /*q_dtype*/,
+                                                 int64_t /*batch_size*/,
+                                                 int64_t /*q_len*/,
+                                                 int64_t /*kv_len*/,
+                                                 int64_t /*n_heads*/,
+                                                 int64_t /*n_kv_heads*/,
+                                                 int64_t /*head_dim*/,
+                                                 float /*logits_soft_cap*/,
+                                                 bool /*alibi*/,
+                                                 int32_t /*sliding_window*/>> {
+ public:
+  void SetUp() override {
+    // Set random seed for test stability
+    torch::manual_seed(0);
+  }
+};
+
+TEST_P(MHAKernelTest, FMHA) {
+  const auto [dtype,
+              batch_size,
+              q_len,
+              kv_len,
+              n_heads,
+              n_kv_heads,
+              head_dim,
+              logits_soft_cap,
+              alibi,
+              sliding_window] = GetParam();
+
+  const auto options = torch::dtype(dtype).device(torch::kCUDA);
+
+  // construct non-contiguous query, key and value
+  const auto data = torch::randn(
+      {batch_size, q_len, n_heads + 2 * n_kv_heads, head_dim}, options);
+  const auto qkv =
+      data.split(/*split_size=*/{n_heads, n_kv_heads, n_kv_heads}, /*dim=*/2);
+  const auto& query = qkv[0];
+  const auto& key = qkv[1];
+  const auto& value = qkv[2];
+
+  torch::optional<torch::Tensor> alibi_slopes;
+  if (alibi) {
+    alibi_slopes = torch::rand(
+        {n_heads}, torch::dtype(torch::kFloat32).device(torch::kCUDA));
+  }
+
+  auto ref_out = mha_batch_ref(
+      query, key, value, alibi_slopes, logits_soft_cap, sliding_window);
+  auto out = sm120_mha(
+      query, key, value, alibi_slopes, logits_soft_cap, sliding_window, q_len);
+
+  if (dtype == torch::kBFloat16) {
+    EXPECT_TRUE(torch::allclose(out, ref_out, /*rtol=*/1e-2, /*atol=*/1e-2));
+  } else {
+    EXPECT_TRUE(torch::allclose(out, ref_out, /*rtol=*/1e-3, /*atol=*/1e-3));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SM120,
+    MHAKernelTest,
+    ::testing::Combine(
+        ::testing::Values(torch::kHalf),                     // q_dtype
+        ::testing::Values(1, 2, 4),                          // batch_size
+        ::testing::Values(1, 62, 125),                       // q_len
+        ::testing::Values(127, 287, 1000),                   // kv_len
+        ::testing::Values(6),                                // n_heads
+        ::testing::Values(6 /*mha*/, 3 /*gqa*/, 1 /*mqa*/),  // n_kv_heads
+        ::testing::Values(64),                               // head_dim
+        ::testing::Values(0.0, 50.0),                        // logits_soft_cap
+        ::testing::Values(false, true),                      // alibi slope
+        ::testing::Values(-1, 0, 10)                         // sliding window
+        ));
+
+}  // namespace llm

--- a/src/kernels/attention/sm120_mha_test.cu
+++ b/src/kernels/attention/sm120_mha_test.cu
@@ -150,17 +150,16 @@ TEST_P(MHAKernelTest, FMHA) {
 INSTANTIATE_TEST_SUITE_P(
     SM120,
     MHAKernelTest,
-    ::testing::Combine(
-        ::testing::Values(torch::kHalf),                     // q_dtype
-        ::testing::Values(1, 2, 4),                          // batch_size
-        ::testing::Values(1, 62, 125),                       // q_len
-        ::testing::Values(127, 287, 1000),                   // kv_len
-        ::testing::Values(6),                                // n_heads
-        ::testing::Values(6 /*mha*/, 3 /*gqa*/, 1 /*mqa*/),  // n_kv_heads
-        ::testing::Values(64),                               // head_dim
-        ::testing::Values(0.0, 50.0),                        // logits_soft_cap
-        ::testing::Values(false, true),                      // alibi slope
-        ::testing::Values(-1, 0, 10)                         // sliding window
-        ));
+    ::testing::Combine(::testing::Values(torch::kHalf),  // q_dtype
+                       ::testing::Values(1),             // batch_size
+                       ::testing::Values(62),            // q_len
+                       ::testing::Values(127),           // kv_len
+                       ::testing::Values(6),             // n_heads
+                       ::testing::Values(6),             // n_kv_heads
+                       ::testing::Values(64),            // head_dim
+                       ::testing::Values(0.0),           // logits_soft_cap
+                       ::testing::Values(false),         // alibi slope
+                       ::testing::Values(-1)             // sliding window
+                       ));
 
 }  // namespace llm

--- a/src/kernels/attention/sm80_collective_mha.cuh
+++ b/src/kernels/attention/sm80_collective_mha.cuh
@@ -10,7 +10,6 @@
 
 #include "fast_cast.cuh"
 #include "layout_convertor.h"
-#include "mask.h"
 #include "safe_copy.h"
 
 namespace llm {
@@ -34,6 +33,9 @@ struct Sm80CollectiveMha {
   static constexpr int kBlockM = get<0>(TileShape{});
   static constexpr int kBlockN = get<1>(TileShape{});
   static constexpr int kBlockK = get<2>(TileShape{});
+
+  static constexpr bool kAlibi = ALIBI;
+  static constexpr bool kLocal = LOCAL;
 
   static_assert(kBlockK == 32 || kBlockK == 64);
   static_assert(kHeadDim % kBlockK == 0);
@@ -117,20 +119,8 @@ struct Sm80CollectiveMha {
 
   // Host side arguments
   struct Arguments {
-    // mask
-    int sliding_window = -1;
-
     // softcap
     float logits_soft_cap = 0.0;
-
-    // softmax scaling
-    float sm_scale = 1.0;
-    float sm_scale_log2 = 0.0;
-
-    // alibi: (n_heads)
-    const float* __restrict__ alibi_slopes_ptr = nullptr;
-
-    FastDivmod group_size;
   };
 
   // Device side params
@@ -151,21 +141,23 @@ struct Sm80CollectiveMha {
             class TensorCMN,
             class FrgTensor,
             class Softmax,
-            class BlockCoord,
+            class Mask,
             class ResidueMNK>
   CUTE_DEVICE void operator()(
       const Params& params,
-      const TensorQ& gQ,     // (BLK_M, HEAD_DIM)
-      const TensorCQ& cQ,    // (BLK_M, HEAD_DIM) => (M, K)
-      const TensorK& gK,     // (BLK_N, HEAD_DIM, n)
-      const TensorV& gV,     // (BLK_N, HEAD_DIM, n)
-      const TensorCKV& cKV,  // (BLK_N, HEAD_DIM, n) => (N, K)
-      const TensorCMN& cMN,  // (BLK_M, BLK_N, n) => (M, N)
-      FrgTensor& tOrO,       // (MMA, MMA_M, MMA_N)
+      const TensorQ& gQ,          // (BLK_M, HEAD_DIM)
+      const TensorCQ& cQ,         // (BLK_M, HEAD_DIM) => (M, K)
+      const TensorK& gK,          // (BLK_N, HEAD_DIM, n)
+      const TensorV& gV,          // (BLK_N, HEAD_DIM, n)
+      const TensorCKV& cKV,       // (BLK_N, HEAD_DIM, n) => (N, K)
+      const TensorCMN& tScMN_mn,  // ((2, MMA_M), (2, MMA_N), n) => (M, N)
+      FrgTensor& tOrO,            // (MMA, MMA_M, MMA_N)
       Softmax& softmax,
+      const Mask& mask,
       int tidx,
-      const BlockCoord& blk_coord,
       const ResidueMNK& residue_mnk,  // (M, N, K)
+      int n_block_min,
+      int n_block_max,
       char* smem) {
     static_assert(is_rmem<FrgTensor>::value,
                   "Accum tensor must be rmem resident.");
@@ -176,17 +168,7 @@ struct Sm80CollectiveMha {
     static constexpr int kBlockM = get<0>(TileShape{});
     static constexpr int kBlockN = get<1>(TileShape{});
 
-    const int q_idx = get<0>(blk_coord);
-    const int kv_head_idx = get<1>(blk_coord);
-    const int q_packed_len = get<0>(residue_mnk);
-    const int kv_len = get<1>(residue_mnk);
-
-    const int sliding_window = LOCAL ? params.sliding_window : kv_len;
-    const float logits_soft_cap = params.logits_soft_cap;
-    const float sm_scale = params.sm_scale;
-    const float sm_scale_log2 = params.sm_scale_log2;
-    const auto& group_size = params.group_size;
-    const int q_len = q_packed_len / group_size;
+    // assert(n_block_min < n_block_max);
 
     // Construct shared memory tiles
     auto& ss = *reinterpret_cast<SharedStorage*>(smem);
@@ -345,23 +327,11 @@ struct Sm80CollectiveMha {
     auto tOrO_mn =
         make_tensor(tOrO.data(), LayoutConvertor::to_mn(tOrO.layout()));
 
-    const int diagonal = q_idx + kv_len - q_len;
-    // process kv in range: [kv_idx_min, kv_idx_max)
-    const int kv_idx_min = std::max(0, diagonal - sliding_window);
-    const int kv_idx_max = std::min(kv_len, diagonal + kBlockM);
-    const int n_block_min = LOCAL ? kv_idx_min / kBlockN : 0;
-    const int n_block_max = cute::ceil_div(kv_idx_max, kBlockN);
-
-    if (n_block_min >= n_block_max) {
-      // no kv blocks to process
-      return;
-    }
-
     auto apply_logits_soft_cap = [&](auto& tSrAccS) {
       if constexpr (SOFT_CAP) {
         CUTE_UNROLL
         for (int i = 0; i < size(tSrAccS); ++i) {
-          tSrAccS(i) = tanh(tSrAccS(i) * logits_soft_cap);
+          tSrAccS(i) = tanh(tSrAccS(i) * params.logits_soft_cap);
         }
       }
     };
@@ -377,7 +347,7 @@ struct Sm80CollectiveMha {
 
     // copy query from smem to rmem
     cute::copy(smem_tiled_copy_Q, tSsQ, tSrQ_copy_view);
-    // wait s2r copy done for query
+    // wait s2r copy done for query before producing key
     __syncthreads();
 
     // produce key: [q] => [q, k]
@@ -393,20 +363,6 @@ struct Sm80CollectiveMha {
     // ((2, MMA_M), (2, MMA_N))
     auto tSrS_mn =
         make_tensor(tSrS.data(), LayoutConvertor::to_mn(tSrS.layout()));
-
-    // (MMA, MMA_M, MMA_N, n)
-    auto tScMN = thr_mma.partition_C(cMN);
-    // ((2, MMA_M), (2, MMA_N), n) => (M, N)
-    auto tScMN_mn =
-        make_tensor(tScMN.data(), LayoutConvertor::to_mn(tScMN.layout()));
-
-    constexpr int kRowsPerThr = kRowsPerMMA * size<1>(tSrS);
-    using Mask = Mask<kRowsPerThr, ALIBI, LOCAL>;
-    Mask mask(q_len, kv_len, group_size, sliding_window);
-    if constexpr (ALIBI) {
-      const auto tScS_mn = tScMN_mn(_, _, _0{});
-      mask.init_alibi(tScS_mn, kv_head_idx, sm_scale, params.alibi_slopes_ptr);
-    }
 
     CUTE_NO_UNROLL
     for (int i = 0; i < n_blocks; ++i) {

--- a/src/kernels/attention/sm80_kernel_mha.cuh
+++ b/src/kernels/attention/sm80_kernel_mha.cuh
@@ -7,6 +7,8 @@
 #include <cute/tensor.hpp>
 
 #include "gather_tensor.hpp"
+#include "layout_convertor.h"
+#include "mask.h"
 #include "mha_params.h"
 #include "online_softmax.cuh"
 
@@ -178,10 +180,6 @@ class Sm80KernelMha {
   using BLK_N = typename CollectiveMainloop::BLK_N;
   using HEAD_DIM = typename CollectiveMainloop::HEAD_DIM;
 
-  static constexpr int kBlockM = CollectiveMainloop::kBlockM;
-
-  static constexpr int kRowsPerMMA = CollectiveMainloop::kRowsPerMMA;
-
   static constexpr int kSharedStorageSize =
       cute::max(sizeof(typename CollectiveMainloop::SharedStorage),
                 sizeof(typename CollectiveEpilogue::SharedStorage));
@@ -204,17 +202,19 @@ class Sm80KernelMha {
   CUTE_DEVICE void operator()(const Params& params,
                               const TileSchedulerParams& scheduler_params,
                               char* smem) {
+    static constexpr int kBlockM = CollectiveMainloop::kBlockM;
+    static constexpr int kBlockN = CollectiveMainloop::kBlockN;
+    static constexpr int kRowsPerMMA = CollectiveMainloop::kRowsPerMMA;
+
+    static constexpr bool kAlibi = CollectiveMainloop::kAlibi;
+    static constexpr bool kLocal = CollectiveMainloop::kLocal;
+
     CollectiveMainloop mha;
     CollectiveEpilogue epilogue;
     TileScheduler scheduler(scheduler_params);
 
     // construct params
-    MainloopParams mainloop_params{params.sliding_window,
-                                   params.logits_soft_cap,
-                                   params.sm_scale,
-                                   params.sm_scale_log2,
-                                   params.alibi_slopes_ptr,
-                                   params.group_size};
+    MainloopParams mainloop_params{params.logits_soft_cap};
     EpilogueParams epilogue_params;
 
     // process each block
@@ -243,6 +243,15 @@ class Sm80KernelMha {
       const auto residue_mnk =
           make_tuple(q_packed_len, kv_len, params.head_dim);
 
+      const int sliding_window = kLocal ? params.sliding_window : kv_len;
+      const int q_len = q_packed_len / group_size;
+
+      const int diagonal = q_idx + kv_len - q_len;
+      const int kv_idx_min = std::max(0, diagonal - sliding_window);
+      const int kv_idx_max = std::min(kv_len, diagonal + kBlockM);
+      const int n_block_min = kLocal ? kv_idx_min / kBlockN : 0;
+      const int n_block_max = cute::ceil_div(kv_idx_max, kBlockN);
+
       // (BLK_M, HEAD_DIM)
       Tensor gQ = local_tile(
           Q, Shape<BLK_M, HEAD_DIM>{}, make_coord(m_block_idx, _0{}));
@@ -268,28 +277,46 @@ class Sm80KernelMha {
                      make_coord(m_block_idx, _));
 
       TiledMma tiled_mma;
-      // accumulator: MMA,MMA_M,MMA_K)
+      // accumulator: (MMA,MMA_M,MMA_K)
       auto tOrAccO = partition_fragment_C(tiled_mma, Shape<BLK_M, HEAD_DIM>{});
       clear(tOrAccO);
 
-      constexpr int kRowsPerThr = kRowsPerMMA * size<1>(tOrAccO);
-      OnlineSoftmax<kRowsPerThr> softmax(params.sm_scale_log2);
+      auto thr_mma = tiled_mma.get_slice(tidx);
+      // (MMA, MMA_M, MMA_N, n) => (M, N)
+      auto tScMN = thr_mma.partition_C(cMN);
+      // ((2, MMA_M), (2, MMA_N), n) => (M, N)
+      auto tScMN_mn =
+          make_tensor(tScMN.data(), LayoutConvertor::to_mn(tScMN.layout()));
 
-      // mainloop
-      const auto blk_coord = make_coord(q_idx, kv_head_idx);
-      mha(mainloop_params,
-          gQ,
-          cQ,
-          gK,
-          gV,
-          cKV,
-          cMN,
-          tOrAccO,
-          softmax,
-          tidx,
-          blk_coord,
-          residue_mnk,
-          smem);
+      constexpr int kRowsPerThr = kRowsPerMMA * size<1>(tOrAccO);
+      // Create softmax and mask
+      OnlineSoftmax<kRowsPerThr> softmax(params.sm_scale_log2);
+      Mask<kRowsPerThr, kAlibi, kLocal> mask(
+          q_len, kv_len, group_size, sliding_window);
+      if constexpr (kAlibi) {
+        const auto tScS_mn = tScMN_mn(_, _, _0{});
+        mask.init_alibi(
+            tScS_mn, kv_head_idx, params.sm_scale, params.alibi_slopes_ptr);
+      }
+
+      // mainloop: process kv in range: [n_block_min, n_block_max)
+      if (n_block_min < n_block_max) {
+        mha(mainloop_params,
+            gQ,
+            cQ,
+            gK,
+            gV,
+            cKV,
+            tScMN_mn,
+            tOrAccO,
+            softmax,
+            mask,
+            tidx,
+            residue_mnk,
+            n_block_min,
+            n_block_max,
+            smem);
+      }
 
       // epilogue
       epilogue(


### PR DESCRIPTION
TODOs:
- [ ] warp-specialization kernel with 2 warpgroups: one for mma and one for copy async
- [ ] load kv cache with tma: 2 warpgroups: 1 warpgroup for mma and 1 warpgroup for tma+copy async
- [ ] pingpong-scheduling to overlap softmax and mma: 2 warpgroups for mma and 1 warpgroup for tma+copy async
- [ ] TMA Store + STMTX for epilogue
- [ ] Overlap epilogue with next attn